### PR TITLE
Playing with names

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -12,6 +12,7 @@
 
 	var/stored_name
 	var/badge_string = "Geminus City Police Department"
+	var/name_reset = ""
 
 /obj/item/clothing/accessory/badge/old
 	name = "faded badge"
@@ -65,6 +66,18 @@
 	icon_state = "holobadge"
 	var/emagged //Emagging removes Sec check.
 
+/obj/item/clothing/accessory/badge/holo/verb/Reset(mob/user as mob)
+	if(access_security in user.GetIdCard().access)
+		if(!stored_name)
+			user << "There is no information stored on the badge."
+		else
+			user << "You reset the holobadge."
+			stored_name = FALSE
+			name = name_reset
+	else
+		user << "[name] rejects your insufficient access rights."
+	return
+
 /obj/item/clothing/accessory/badge/holo/cord
 	icon_state = "holobadge-cord"
 	slot_flags = SLOT_MASK | SLOT_TIE | SLOT_BELT
@@ -97,6 +110,8 @@
 
 		if(access_security in id_card.access || emagged)
 			user << "You imprint your ID details onto the badge."
+			if (!name_reset)
+				name_reset = name
 			set_name(user.real_name)
 		else
 			user << "[src] rejects your insufficient access rights."

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -1,3 +1,31 @@
+/atom/var/name_unlabel = ""
+
+// Yes, this is totally worth a new variable and a proc!
+/atom/proc/unlabel()
+	set name = "Remove Label"
+	set category = "Object"
+	set src in view(1)
+
+	if (!usr.IsAdvancedToolUser() || usr.incapacitated())
+		to_chat(usr, "<span class='notice'>You lack the dexerity to do this!</span>")
+		return FALSE
+
+	if (!name_unlabel)
+		to_chat(usr, "<span class='notice'>You look again, unable to find the label! Perhaps your eyes need checking?</span>")
+		src.verbs -= .proc/unlabel
+		return FALSE
+
+	var/mob/living/carbon/human/H = usr
+
+	name = name_unlabel
+	name_unlabel = ""
+	src.verbs -= .proc/unlabel
+
+	H.visible_message("<span class='notice'>\The [H] removes the label from \the [src].</span>",
+		"<span class='notice'>You remove the label from \the [src].</span>")
+
+	return TRUE
+
 /obj/item/weapon/hand_labeler
 	name = "hand labeler"
 	icon = 'icons/obj/bureaucracy.dmi'
@@ -49,6 +77,12 @@
 
 	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
 						 "<span class='notice'>You label [A] as [label].</span>")
+
+	// Prevent label stacking from making name unrecoverable.
+	if (!A.name_unlabel)
+		A.name_unlabel = A.name
+		A.verbs += /atom/proc/unlabel
+
 	A.name = "[A.name] ([label])"
 
 /obj/item/weapon/hand_labeler/attack_self(mob/user as mob)


### PR DESCRIPTION
- Ported the ability to remove labels created by hand labeler from Aurora
- Added the ability to reset the name on holobadges, making them reusable