### PR TITLE
Concept of Anonimity (finished)

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -153,7 +153,7 @@
 		if ("modify")
 			if (modify)
 				data_core.manifest_modify(modify.registered_name, modify.assignment)
-				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
+				modify.name = text("ID Card")
 				if(ishuman(usr))
 					modify.forceMove(get_turf(src))
 					if(!usr.get_active_hand())

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,7 +1,5 @@
 /mob/living/carbon/human/say(var/message,var/whispering=0)
 	var/alt_name = ""
-	if(name != GetVoice())
-		alt_name = "(as [get_id_name("Unknown")])"
 
 	message = sanitize(message)
 	..(message, alt_name = alt_name, whispering = whispering)


### PR DESCRIPTION
- id modification console now doesn't put name in the card's item description
- talking does not reveal your id
- examining a person doesn't show their id in their id slot
- id cards now don't have names in their item description