### PR TITLE
Shows confirmation messages for IC and OOC to prevent common accidents.

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -15,6 +15,17 @@
 	msg = sanitize(msg)
 	if(!msg)	return
 
+	var/raw_msg = msg
+
+
+	if((copytext(msg, 1, 2) in list(".",";",":","#","say","whisper","me")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
+			return
+
+	if((copytext(msg, 1, 2) in list("me")) || (findtext(lowertext(copytext(msg, 1, 5)), "me")))
+		if(alert("Your message \"[raw_msg]\" looks like it was meant to be emoted, of course we might be wrong, say it in OOC still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
+			return
+
 	if(!is_preference_enabled(/datum/client_preference/show_ooc))
 		src << "<span class='warning'>You have OOC muted.</span>"
 		return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -182,6 +182,14 @@ proc/get_radio_key_from_channel(var/channel)
 		speaking.broadcast(src,trim(message))
 		return 1
 
+	//If it looks like accidental IC-OOK/emoting
+	if((copytext(message, 1, 2) in list("say","me")) || (findtext(lowertext(copytext(message, 1, 5)), "ooc")))
+		if(alert("Your message \"[message]\" looks like it was meant for OOC instead of IC, say it in IC still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
+			return
+
+	if((copytext(message, 1, 2) in list("say")) || (findtext(lowertext(copytext(message, 1, 5)), "me")))
+		if(alert("Your message \"[message]\" begins with me so it may be an emote, was it? Say it in IC speech still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
+			return
 	//Self explanatory.
 	if(is_muzzled() && !(speaking && (speaking.flags & SIGNLANG)))
 		src << "<span class='danger'>You're muzzled and cannot speak!</span>"


### PR DESCRIPTION
Ever had that annoying issue where you accidentally say "say Oh my god the Mayor's stealing from the city!" in OOC?

Partially ported from /tg/ with some adjustment, this should help reduce:

- IC in OOC messages beginning with "say" or "me"
- IC in OOC messages that were likely meant for a department radio beginning with ":" or ";"
- OOC in IC messages beginning with "OOC"
- Emotes in Say commands beginning with "me"

It doesn't prevent you from saying the message, just sends a friendly dialogue asking if you want the message to still go through.