### PR TITLE
Removes Communcators from loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -12,7 +12,7 @@
 	display_name = "text to speech device"
 	path = /obj/item/device/text_to_speech
 	cost = 3 //Not extremely expensive, but it's useful for mute chracters.
-
+/*
 /datum/gear/utility/communicator
 	display_name = "communicator selection"
 	path = /obj/item/device/communicator
@@ -25,7 +25,7 @@
 		var/obj/item/device/communicator_type = communicator
 		communicators[initial(communicator_type.name)] = communicator_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(communicators))
-
+*/
 /datum/gear/utility/camera
 	display_name = "camera"
 	path = /obj/item/device/camera


### PR DESCRIPTION
Hopefully this should stop duplicate communicators from appearing in contact list.

Once we have a few more communicator ports (like uplink, PDA explosions, etc) that allow you to use all the features of PDAs, we'll replace the equip_PDA proc with equip_communicator proc.