### PR TITLE
Makes the ic/ooc check less annoying

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -18,12 +18,8 @@
 	var/raw_msg = msg
 
 
-	if((copytext(msg, 1, 2) in list(".",";",":","#","say","whisper","me")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+	if((copytext(msg, 1, 2) in list(".",";",":","#","say")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
 		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
-			return
-
-	if((copytext(msg, 1, 2) in list("me")) || (findtext(lowertext(copytext(msg, 1, 5)), "me")))
-		if(alert("Your message \"[raw_msg]\" looks like it was meant to be emoted, of course we might be wrong, say it in OOC still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
 			return
 
 	if(!is_preference_enabled(/datum/client_preference/show_ooc))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -187,9 +187,6 @@ proc/get_radio_key_from_channel(var/channel)
 		if(alert("Your message \"[message]\" looks like it was meant for OOC instead of IC, say it in IC still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
 			return
 
-	if((copytext(message, 1, 2) in list("say")) || (findtext(lowertext(copytext(message, 1, 5)), "me")))
-		if(alert("Your message \"[message]\" begins with me so it may be an emote, was it? Say it in IC speech still?", "Confirm if meant for IC?", "No", "Yes") != "Yes")
-			return
 	//Self explanatory.
 	if(is_muzzled() && !(speaking && (speaking.flags & SIGNLANG)))
 		src << "<span class='danger'>You're muzzled and cannot speak!</span>"


### PR DESCRIPTION
In foresight, the "me" command is way too frequently used within words to be auto checked.