### PR TITLE
Fixes picket signs

### DIFF
--- a/code/game/objects/items/weapons/signs.dm
+++ b/code/game/objects/items/weapons/signs.dm
@@ -14,8 +14,10 @@
 
 /obj/item/weapon/picket_sign/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/weapon/pen/crayon))
-		var/txt = sanitize(input(user, "What would you like to write on the sign?", "Sign Label", null , 30)  as text)
-		if(txt)
+		var/txt = sanitize(copytext(input(user, "Enter your picket message.", "Picket Message", null)  as text,1,40))
+		if(!txt)
+			return
+		else
 			label = txt
 			src.name = "[label] sign"
 			desc =	"It reads: [label]"


### PR DESCRIPTION
Picket signs were showing a strange error before. Now they work as they should do.

**Before:**
![image](https://user-images.githubusercontent.com/12565163/50450973-13ae2600-0929-11e9-8c00-088bbaa5a01a.png)

**After:**
![image](https://user-images.githubusercontent.com/12565163/50450967-098c2780-0929-11e9-92fc-82789bd0f172.png)
