### PR TITLE
Adds more contraband + Ecstasy Reagent Issue

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_contraband.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_contraband.dm
@@ -1,55 +1,80 @@
 // Items of questionable nature.
+/datum/gear/contraband/
+	display_name = "poster"
+	description = "Random posters of various things."
+	path = /obj/item/weapon/contraband/poster
+	sort_category = "Contraband"
+	cost = 2
+
+/datum/gear/contraband/picket
+	display_name = "picket sign"
+	description = "Take this out and wave it around at every opportunity."
+	path = /obj/item/weapon/picket_sign
+	sort_category = "Contraband"
+	cost = 2
+
 /datum/gear/contraband/weapon
 	display_name = "switchblade"
+	description = "A swift solution for the unexpected street fight."
 	path = /obj/item/weapon/material/butterfly/switchblade
 	sort_category = "Contraband"
 	cost = 8
 
 /datum/gear/contraband/weapon/bat
-	display_name = "metal bat"
+	display_name = "wooden bat"
+	description = "Think fast! For games, obviously."
 	path = /obj/item/weapon/material/twohanded/baseballbat
 	cost = 10
 
 /datum/gear/contraband/drug_syringe
 	display_name = "syringe (various drugs)"
+	description = "You're not 100% sure what is in this, just inject into your veins and hope for the best."
 	path = /obj/item/weapon/reagent_containers/syringe/drugs
 	sort_category = "Contraband"
 	cost = 4
 
-/datum/gear/contraband/weapon/zipgun
+/datum/gear/contraband/zipgun
 	display_name = "zipgun"
+	description = "A small handgun, for self defense (usually)."
 	path = /obj/item/weapon/gun/projectile/pirate/thug
 	cost = 10
 
-/datum/gear/contraband/ammo/zipgun
+/datum/gear/contraband/zipgun_ammo
 	display_name = "12g shells"
 	description = "Home-made pellets of death and destruction in an incospicuous box"
 	path = /obj/item/weapon/storage/box/shotgunammo/contraband
 	sort_category = "Contraband"
 	cost = 8
 
-/datum/gear/contraband/drug/baggie/cannabis
+/datum/gear/contraband/baggie
+	display_name = "baggie"
+	description = "A small plastic baggie, for whatever small plastic baggies are for."
+	path = /obj/item/weapon/reagent_containers/drugs/baggie
+	sort_category = "Contraband"
+	cost = 2
+
+/datum/gear/contraband/baggie/cannabis
 	display_name = "baggie (Cannabis)"
 	description = "A painkilling and toxin healing drug. THC is found in this, and is extracted from the cannabis plant."
 	path = /obj/item/weapon/reagent_containers/drugs/baggie/cannabis
 	sort_category = "Contraband"
 	cost = 8
 
-/datum/gear/contraband/drug/baggie/meth
+/datum/gear/contraband/baggie/meth
 	display_name = "baggie (Meth)"
 	description = "I'm sure 'just once' won't hurt you, right?"
 	path = /obj/item/weapon/reagent_containers/drugs/baggie/meth
 	sort_category = "Contraband"
 	cost = 10
 
-/datum/gear/contraband/drug/baggie/heroin
+/datum/gear/contraband/baggie/heroin
 	display_name = "baggie (Heroin)"
 	description = "Heroin, also known as diamorphine is a potent opiate with strong painkilling effects. When you need to chase that dragon."
 	path = /obj/item/weapon/reagent_containers/drugs/baggie/heroin
 	sort_category = "Contraband"
 	cost = 12
 
-/datum/gear/contraband/drug/box/ecstasy
+/datum/gear/contraband/ecstasy
 	display_name = "ecstasy pill bottle"
 	description = "Also known as MDMA. An illegal chemical compound used as a drug. Do it for the lit parties."
 	path = /obj/item/weapon/storage/pill_bottle/ecstasy

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -7,7 +7,7 @@
 	"You're on top of the world!")
 	taste_description = "something weird"
 	var/high_message_chance = 10
-	color = "f2f2f2"
+	color = "#f2f2f2"
 	scannable = 1
 	overdose = REAGENTS_OVERDOSE
 


### PR DESCRIPTION
* Picket signs, posters, and adds descriptions to drugs and weapons as this was causing  gameboot warnings.
* Changes bat name to wooden, as that's how it appears in-game.
* Adds a hash to the hex color number of ecstasy, stopping errors.