### PR TITLE
[Temporary Measure] Makes zombies and malfs non-votable

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -10,4 +10,4 @@
 	auto_recall_shuttle = 0
 	antag_tags = list(MODE_MALFUNCTION)
 	disabled_jobs = list("AI")
-	votable = 0
+	votable = 0 //Until this mode is fixed.

--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -7,5 +7,6 @@
 	required_players = 1
 	required_players_secret = 1
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = 1
 	restricted_jobs = list("AI", "Cyborg","Chief Medical Officer", "Doctor", "Virologist")
+	votable = 0 //Until this mode is fixed.


### PR DESCRIPTION
* Zombie and malf can no longer be voted.
* Doing this until we can figure out apc hacking for malf ais, and zombie nerfs for picking up items and wearing clothing.