### PR TITLE
Makes APCs charge without an engine

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -71,8 +71,8 @@
 	var/areastring = null
 	var/obj/item/weapon/cell/cell
 	var/chargelevel = 0.0005  // Cap for how fast APC cells charge, as a percentage-per-tick (0.01 means cellcharge is capped to 1% per second)
-	var/start_charge = 90				// initial cell charge %
-	var/cell_type = /obj/item/weapon/cell/apc
+	var/start_charge = 100				// initial cell charge %
+	var/cell_type = /obj/item/weapon/cell/apc/infinite
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
 	var/grid_check = FALSE
@@ -80,7 +80,7 @@
 	var/equipment = POWERCHAN_ON_AUTO
 	var/environ = POWERCHAN_ON_AUTO
 	var/operating = 1
-	var/charging = 0
+	var/charging = 1
 	var/chargemode = 1
 	var/chargecount = 0
 	var/locked = 1

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -25,6 +25,13 @@
 	maxcharge = 5000
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 
+
+/obj/item/weapon/cell/apc/infinite/check_charge()
+	return 1
+
+/obj/item/weapon/cell/apc/infinite/use()
+	return 1
+
 /obj/item/weapon/cell/high
 	name = "high-capacity power cell"
 	origin_tech = list(TECH_POWER = 2)


### PR DESCRIPTION
We don't have an engine. so let's sort that out shall we?

* Makes APC cells have infinite use.
* Charging is always set to 1 because there's an off-screen powerplant somewhere

Todo: Make it impossible for APC powercells to be used in anything else to prevent abuse.

Temporary measure until powerplants are actually implemented.