### PR TITLE
Adds the ability to use markup in text

### DIFF
--- a/code/__defines/regex.dm
+++ b/code/__defines/regex.dm
@@ -1,0 +1,37 @@
+// Global REGEX datums for regular use without recompiling
+
+// The lazy URL finder. Lazy in that it matches the bare minimum
+// Replicates BYOND's own URL parser in functionality.
+var/global/regex/url_find_lazy
+
+// REGEX datums used for process_chat_markup.
+var/global/regex/markup_bold
+var/global/regex/markup_italics
+var/global/regex/markup_strike
+var/global/regex/markup_underline
+
+// Global list for mark-up REGEX datums.
+// Initialized in the hook, to avoid passing by null value.
+var/global/list/markup_regex = list()
+
+// Global list for mark-up REGEX tag collection.
+var/global/list/markup_tags = list("/" = list("<i>", "</i>"),
+						"*" = list("<b>", "</b>"),
+						"~" = list("<strike>", "</strike>"),
+						"_" = list("<u>", "</u>"))
+
+/hook/startup/proc/initialize_global_regex()
+	url_find_lazy = new("((https?|byond):\\/\\/\[^\\s\]*)", "g")
+
+	markup_bold = 		new("((\\W|^)\\*)(\[^\\*\]*)(\\*(\\W|$))", "g")
+	markup_italics = 	new("((\\W|^)\\/)(\[^\\/\]*)(\\/(\\W|$))", "g")
+	markup_strike = 	new("((\\W|^)\\~)(\[^\\~\]*)(\\~(\\W|$))", "g")
+	markup_underline = 	new("((\\W|^)\\_)(\[^\\_\]*)(\\_(\\W|$))", "g")
+
+	// List needs to be initialized here, due to DM mixing and matching pass-by-value and -reference as it chooses.
+	markup_regex = list("/" = markup_italics,
+						"*" = markup_bold,
+						"~" = markup_strike,
+						"_" = markup_underline)
+
+	return 1

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -387,5 +387,36 @@ proc/TextPreview(var/string,var/len=40)
 	if(rest)
 		. += .(rest)
 
+// For processing simple markup, similar to what Skype and Discord use.
+// Enabled from a config setting.
+/proc/process_chat_markup(var/message, var/list/ignore_tags = list())
+	if (!config.allow_chat_markup)
+		return message
+
+	if (!message)
+		return ""
+
+	// ---Begin URL caching.
+	var/list/urls = list()
+	var/i = 1
+	while (url_find_lazy.Find(message))
+		urls["\ref[urls]-[i]"] = url_find_lazy.match
+		i++
+
+	for (var/ref in urls)
+		message = replacetextEx(message, urls[ref], ref)
+	// ---End URL caching
+
+	var/regex/tag_markup
+	for (var/tag in (markup_tags - ignore_tags))
+		tag_markup = markup_regex[tag]
+		message = tag_markup.Replace(message, "$2[markup_tags[tag][1]]$3[markup_tags[tag][2]]$5")
+
+	// ---Unload URL cache
+	for (var/ref in urls)
+		message = replacetextEx(message, ref, urls[ref])
+
+	return message
+
 
 #define gender2text(gender) capitalize(gender)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -219,7 +219,7 @@ var/list/gamemode_cache = list()
 	var/aggressive_changelog = 0
 
 	var/list/language_prefixes = list(",","#","-")//Default language prefixes
-
+	var/allow_chat_markup = 0 // Mark-up enabling
 	var/show_human_death_message = 1
 
 	var/radiation_decay_rate = 1 //How much radiation is reduced by each tick
@@ -625,6 +625,9 @@ var/list/gamemode_cache = list()
 
 				if("uneducated_mice")
 					config.uneducated_mice = 1
+
+				if("allow_chat_markup")
+					config.allow_chat_markup = 1
 
 				if("comms_password")
 					config.comms_password = value

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -205,6 +205,9 @@ proc/get_radio_key_from_channel(var/channel)
 	if(!(p_ending in list(".","?","!")))
 		message = p_message
 
+	//Allow them use to markup, if used.
+	message = process_chat_markup(message, list("~", "_"))
+
 	//Whisper vars
 	var/w_scramble_range = 5	//The range at which you get ***as*th**wi****
 	var/w_adverb				//An adverb prepended to the verb in whispers

--- a/polaris.dme
+++ b/polaris.dme
@@ -44,6 +44,7 @@
 #include "code\__defines\planets.dm"
 #include "code\__defines\process_scheduler.dm"
 #include "code\__defines\qdel.dm"
+#include "code\__defines\regex.dm"
 #include "code\__defines\research.dm"
 #include "code\__defines\sound.dm"
 #include "code\__defines\species_languages.dm"


### PR DESCRIPTION
Ported from Bay/Aurora, allows you to use markup in text.

```
_Underscore for underline._
~Tildes for strikethrough.~
*Asterisks for bold.*
/Forward slash for italics./
```