### PR TITLE
Yeets objects on the ground when turning into a zombie (Fix Issue #97)

### DIFF
--- a/code/modules/mob/living/carbon/zombie/zombie_transform.dm
+++ b/code/modules/mob/living/carbon/zombie/zombie_transform.dm
@@ -46,6 +46,10 @@
 
 /mob/living/carbon/human/proc/zombify()
 	set_species("Zombie")
+
+	for(var/obj/item/W in src)
+		src.drop_from_inventory(W)
+
 	revive()
 
 	infected.add_antagonist(mind)


### PR DESCRIPTION
Just makes all objects drop at the person's feet once they are turned into a zombie. (#97 )
This includes clothing and carried objects.