### PR TITLE
Zombie Updates

### DIFF
--- a/code/game/antagonist/station/zombie.dm
+++ b/code/game/antagonist/station/zombie.dm
@@ -21,7 +21,7 @@ var/datum/antagonist/zombie/infected
 	initial_spawn_req = 2
 	initial_spawn_target = 4
 
-	spawn_announcement = "A deadly and contagious outbreak of the cordyceps parasite has taken over a quarantined neighbouring city. This parasite can be prevented or slowed down with inaprovaline but once symptoms manifest it is incurable. Civilians are advised to report strange flu-like symptoms to their local hospital."
+	spawn_announcement = "A deadly and contagious outbreak of the cordyceps parasite has taken over a quarantined neighbouring city. This parasite can be prevented or slowed down with inaprovaline but once symptoms manifest it is incurable, those afflicted with the late stages of infection must be cremated in order to contain the outbreak. Civilians are advised to report strange flu-like symptoms to their local hospital."
 	spawn_announcement_title = "Pathogen Alert"
 	spawn_announcement_delay = 5000
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -233,6 +233,9 @@ Class Procs:
 		return 1
 	if(user.lying || user.stat)
 		return 1
+	if(isundead(usr))
+		user << "<span class='notice'>This looks incredibly alien to you, and doesn't have brains.</span>"
+		return 1
 	if(!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/living/silicon)))
 		usr << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -204,6 +204,12 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 /obj/item/attack_hand(mob/living/user as mob)
 	if (!user) return
+
+	//if you're not supposed to be able to pick things up, don't pick 'em up.
+	if(isundead(usr))
+		user << "<span class='notice'>You're not sure what to do with this.</span>"
+		return
+
 	if (hasorgans(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
@@ -220,8 +226,18 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	src.pickup(user)
 
 	//If it's a certain type of object, log it for admins, quite useful in some situations.
-	if(istype(src, /obj/item/weapon))
-		usr.attack_log += "\[[time_stamp()]\] <font color='blue'>Has picked up [src] from [src.loc.loc].</font>"
+	if(istype(src, /obj/item/weapon/melee))
+		usr.attack_log += "\[[time_stamp()]\] <font color='blue'>Has picked up the melee object <b>[src]</b> from [src.loc.loc].</font>"
+
+	if(istype(src, /obj/item/weapon/gun))
+		usr.attack_log += "\[[time_stamp()]\] <font color='blue'>Has picked up the gun object <b>[src]</b> from [src.loc.loc].</font>"
+
+	if(istype(src, /obj/item/weapon/reagent_containers))
+		usr.attack_log += "\[[time_stamp()]\] <font color='blue'>Has picked up the reagent container <b>[src]</b> from [src.loc.loc].</font>"
+
+	if(istype(src, /obj/item/weapon/disk/nuclear))
+		usr.attack_log += "\[[time_stamp()]\] <font color='blue'>Has picked up the <b>[src]</b> from [src.loc.loc].</font>"
+
 
 	if (istype(src.loc, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = src.loc

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -205,3 +205,9 @@
 		B.time_to_live = 1
 		burning_objects -= src
 		visible_message("<span class='notice'>The [src]'s flames dissipate.</span>")
+
+/obj/attack_hand(var/mob/user)
+	if(isundead(user))
+		user << "<span class='notice'>This looks incredibly alien to you, and doesn't have brains.</span>"
+		return
+	..()

--- a/code/modules/mob/living/carbon/zombie/zombie_species.dm
+++ b/code/modules/mob/living/carbon/zombie/zombie_species.dm
@@ -124,7 +124,7 @@
 	if(target.internal_organs_by_name["zombie"])
 		to_chat(user, "<span class='danger'>You feel that \the [target] has been already infected!</span>")
 
-	var/infection_chance = 50
+	var/infection_chance = 25
 	var/armor = target.run_armor_check(zone,"melee")
 	infection_chance -= armor
 	if(prob(infection_chance))

--- a/code/modules/mob/living/carbon/zombie/zombie_transform.dm
+++ b/code/modules/mob/living/carbon/zombie/zombie_transform.dm
@@ -45,7 +45,13 @@
 				H.remove_language(L.name)
 
 /mob/living/carbon/human/proc/zombify()
+	for(var/datum/antagonist/zombie/W)
+		W.add_antagonist(mind)
+
 	set_species("Zombie")
+
+	for(var/obj/item/W in src)
+		src.drop_from_inventory(W)
+
 	revive()
 
-	infected.add_antagonist(mind)


### PR DESCRIPTION
* Stops zombies from picking up items and using objects.
* Makes sure all zombies show the hud indicator to each other so they don't attack each other.
* Ensures that cremation information is given IC'ly to civilians (through command reports)
* Reduces infection chance from 50% to 25% (even lower if armor is worn)

**To-do:**
*Find a way to prevent zombies from buckling people into cars. They are unable to unbuckle for now.

*Also find out a mechanical way to prevent spawn camping.