### PR TITLE
Job refactoring

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -66,14 +66,14 @@
 	id_type = /obj/item/weapon/card/id/civilian/janitor
 	pda_type = /obj/item/device/pda/janitor
 
-/decl/hierarchy/outfit/job/librarian
+/decl/hierarchy/outfit/job/civilian/librarian
 	name = OUTFIT_JOB_NAME("Librarian")
 	uniform = /obj/item/clothing/under/suit_jacket/red
 	l_hand = /obj/item/weapon/barcodescanner
 	id_type = /obj/item/weapon/card/id/civilian/librarian
 	pda_type = /obj/item/device/pda/librarian
 
-/decl/hierarchy/outfit/job/chaplain
+/decl/hierarchy/outfit/job/civilian/chaplain
 	name = OUTFIT_JOB_NAME("Chaplain")
 	uniform = /obj/item/clothing/under/rank/chaplain
 	l_hand = /obj/item/weapon/storage/bible
@@ -97,7 +97,7 @@
 	r_pocket = /obj/item/device/gps/explorer
 	id_pda_assignment = "Explorer"
 
-/decl/hierarchy/outfit/job/barber
+/decl/hierarchy/outfit/job/civilian/barber
 	name = OUTFIT_JOB_NAME("Barber")
 	id_type = /obj/item/weapon/card/id/civilian/barber
 	r_pocket = /obj/item/device/communicator
@@ -105,7 +105,7 @@
 	r_pocket = /obj/item/weapon/scissors/barber
 
 
-/decl/hierarchy/outfit/job/judge
+/decl/hierarchy/outfit/job/heads/judge
 	name = OUTFIT_JOB_NAME("Judge")
 	l_ear = /obj/item/device/radio/headset/ia
 	uniform = /obj/item/clothing/under/suit_jacket/charcoal
@@ -114,10 +114,10 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/device/communicator
 	l_hand = /obj/item/weapon/clipboard
-	id_type = /obj/item/weapon/card/id/civilian/judge
+	id_type = /obj/item/weapon/card/id/heads/judge
 	pda_type = /obj/item/device/pda/lawyer
 
-/decl/hierarchy/outfit/job/defense
+/decl/hierarchy/outfit/job/civilian/defense/defense
 	name = OUTFIT_JOB_NAME("Defense Attorney")
 	l_ear = /obj/item/device/radio/headset/ia
 	uniform = /obj/item/clothing/under/lawyer/blue

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/captain
+/decl/hierarchy/outfit/job/heads/captain
 	name = OUTFIT_JOB_NAME("Mayor")
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/rank/captain
@@ -11,12 +11,12 @@
 	pda_type = /obj/item/device/pda/captain
 	r_pocket = /obj/item/device/communicator
 
-/decl/hierarchy/outfit/job/captain/pre_equip(mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/heads/captain/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.gender == FEMALE)
 		uniform = /obj/item/clothing/under/rank/captain/skirt
 
-/decl/hierarchy/outfit/job/captain/post_equip(var/mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/heads/captain/post_equip(var/mob/living/carbon/human/H)
 	..()
 	if(H.age>49)
 		// Since we can have something other than the default uniform at this
@@ -29,7 +29,7 @@
 			else
 				qdel(medal)
 
-/decl/hierarchy/outfit/job/hop
+/decl/hierarchy/outfit/job/heads/hop
 	name = OUTFIT_JOB_NAME("City Supervisor")
 	uniform = /obj/item/clothing/under/rank/head_of_personnel_whimsy
 	l_ear = /obj/item/device/radio/headset/heads/hop
@@ -37,7 +37,7 @@
 	id_type = /obj/item/weapon/card/id/silver/hop
 	pda_type = /obj/item/device/pda/heads/hop
 
-/decl/hierarchy/outfit/job/secretary
+/decl/hierarchy/outfit/job/heads/secretary
 	name = OUTFIT_JOB_NAME("City Hall Guard")
 	l_ear = /obj/item/device/radio/headset/headset_com
 	shoes = /obj/item/clothing/shoes/brown
@@ -45,14 +45,14 @@
 	pda_type = /obj/item/device/pda/heads/hop
 	r_hand = /obj/item/weapon/clipboard
 
-/decl/hierarchy/outfit/job/secretary/pre_equip(mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/heads/secretary/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.gender == FEMALE)
 		uniform = /obj/item/clothing/under/suit_jacket/female/skirt
 	else
 		uniform = /obj/item/clothing/under/suit_jacket/charcoal
 
-/decl/hierarchy/outfit/job/president
+/decl/hierarchy/outfit/job/heads/president
 	name = OUTFIT_JOB_NAME("President")
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/rank/president
@@ -66,7 +66,7 @@
 	pda_type = /obj/item/device/pda/captain
 	r_pocket = /obj/item/device/communicator
 
-/decl/hierarchy/outfit/job/president/post_equip(var/mob/living/carbon/human/H)
+/decl/hierarchy/outfit/job/heads/president/post_equip(var/mob/living/carbon/human/H)
 	..()
 	var/obj/item/clothing/uniform = H.w_uniform
 	if(uniform)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -1,6 +1,8 @@
 var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
-/datum/job/captain
+/datum/job/heads/ // this is just for grabbing all of them at once
+
+/datum/job/heads/captain
 	title = "Mayor"
 	flag = CAPTAIN
 	department = "Command"
@@ -21,19 +23,19 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimum_character_age = 30
 	ideal_character_age = 50 // Old geezer captains ftw // Get your MILF/DILF fetish out of here
 
-	outfit_type = /decl/hierarchy/outfit/job/captain
+	outfit_type = /decl/hierarchy/outfit/job/heads/captain
 //	alt_titles = list("Site Manager", "Overseer")
 
 /*
-/datum/job/captain/equip(var/mob/living/carbon/human/H)
+/datum/job/heads/captain/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(src)
 */
-/datum/job/captain/get_access()
+/datum/job/heads/captain/get_access()
 	return get_all_station_access()
 
-/datum/job/president
+/datum/job/heads/president
 	title = "President"
 	flag = PRESIDENT
 	department = "Command"
@@ -53,14 +55,14 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	minimum_character_age = 30
 	ideal_character_age = 50
-	outfit_type = /decl/hierarchy/outfit/job/president
+	outfit_type = /decl/hierarchy/outfit/job/heads/president
 
-/datum/job/president/get_access()
+/datum/job/heads/president/get_access()
 	get_all_station_access()
 	get_all_centcom_access()
 	return
 
-/datum/job/hop
+/datum/job/heads/hop
 	title = "City Supervisor"
 	flag = HOP
 	department = "Command"
@@ -79,7 +81,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimum_character_age = 25
 	ideal_character_age = 40
 
-	outfit_type = /decl/hierarchy/outfit/job/hop
+	outfit_type = /decl/hierarchy/outfit/job/heads/hop
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
@@ -94,7 +96,25 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
-/datum/job/secretary
+/datum/job/heads/judge
+	title = "Judge"
+	flag = JUDGE
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the city supervisor"
+	selection_color = "#515151"
+	idtype = /obj/item/weapon/card/id/heads/judge
+	economic_modifier = 13
+	access = list(access_judge, access_sec_doors, access_maint_tunnels, access_heads)
+	minimal_access = list(access_judge, access_sec_doors, access_heads)
+	minimal_player_age = 7
+	minimum_character_age = 25
+	alt_titles = list("Magistrate")
+
+	outfit_type = /decl/hierarchy/outfit/job/heads/judge
+
+
+/datum/job/heads/secretary
 	title = "City Hall Guard"
 	flag = BRIDGE
 	department = "Security"
@@ -112,5 +132,5 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	access = list(access_heads, access_keycard_auth, access_security, access_sec_doors)
 	minimal_access = list(access_heads, access_keycard_auth, access_security, access_sec_doors)
 
-	outfit_type = /decl/hierarchy/outfit/job/secretary
+	outfit_type = /decl/hierarchy/outfit/job/heads/secretary
 	alt_titles = list("Public Bodyguard", "City Hall Security", "Bailiff")

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -1,8 +1,8 @@
 //Food
 /datum/job/civilian // stop being garbage with copypasta and your hierarchies I swear to fuck
-department = "Civilian"
-department_flag = CIVILIAN
-faction = "Station"
+	department = "Civilian"
+	department_flag = CIVILIAN
+	faction = "Station"
 
 /datum/job/civilian/bartender
 	title = "Bartender"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -1,10 +1,12 @@
 //Food
-/datum/job/bartender
+/datum/job/civilian // stop being garbage with copypasta and your hierarchies I swear to fuck
+department = "Civilian"
+department_flag = CIVILIAN
+faction = "Station"
+
+/datum/job/civilian/bartender
 	title = "Bartender"
 	flag = BARTENDER
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the city supervisor"
@@ -18,12 +20,9 @@
 	alt_titles = list("Waiting Staff","Barkeep","Mixologist","Barista" = /decl/hierarchy/outfit/job/service/bartender/barista)
 
 
-/datum/job/chef
+/datum/job/civilian/chef
 	title = "Chef"
 	flag = CHEF
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the city supervisor"
@@ -36,12 +35,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/service/chef
 	alt_titles = list("Cook","Restaurant Host")
 
-/datum/job/hydro
+/datum/job/civilian/hydro
 	title = "Botanist"
 	flag = BOTANIST
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 1
 	supervisors = "the city supervisor"
@@ -54,13 +50,11 @@
 	alt_titles = list("Hydroponicist", "Gardener","Farmer")
 
 //Cargo
-/datum/job/qm
+/datum/job/civilian/qm
 	title = "Factory Manager"
 	flag = QUARTERMASTER
 	department = "Cargo"
 	head_position = 1
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the city supervisor"
@@ -71,16 +65,13 @@
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimum_character_age = 20
 	ideal_character_age = 35
-
 	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
 	alt_titles = list("Supply Chief")
 
-/datum/job/cargo_tech
+/datum/job/civilian/cargo_tech
 	title = "Factory Worker"
 	flag = CARGOTECH
 	department = "Cargo"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the factory manager and city supervisor"
@@ -92,12 +83,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 	alt_titles = list("Delivery Assistant")
 
-/datum/job/mining
+/datum/job/civilian/mining
 	title = "Miner"
 	flag = MINER
 	department = "Cargo"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the factory manager and city supervisor"
@@ -111,12 +100,9 @@
 	alt_titles = list("Drill Technician","Prospector")
 
 //Service
-/datum/job/janitor
+/datum/job/civilian/janitor
 	title = "Janitor"
 	flag = JANITOR
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the city supervisor"
@@ -129,12 +115,9 @@
 	alt_titles = list("Custodian", "Sanitation Technician")
 
 //More or less assistants
-/datum/job/librarian
+/datum/job/civilian/librarian
 	title = "Librarian"
 	flag = LIBRARIAN
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the city supervisor"
@@ -143,16 +126,12 @@
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
 
-	outfit_type = /decl/hierarchy/outfit/job/librarian
+	outfit_type = /decl/hierarchy/outfit/job/civilian/librarian
 	alt_titles = list("Journalist", "Professor", "Historian", "Writer")
 
-//var/global/lawyer = 0//Checks for another lawyer //This changed clothes on 2nd lawyer, both IA get the same dreds.
-/datum/job/defense
+/datum/job/civilian/defense
 	title = "Defense Attorney"
 	flag = LAWYER
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the city supervisor"
@@ -165,42 +144,11 @@
 	minimum_character_age = 20
 	alt_titles = list("Defense Lawyer","Defense Attorney","Barrister")
 
-	outfit_type = /decl/hierarchy/outfit/job/defense
+	outfit_type = /decl/hierarchy/outfit/job/civilian/defense
 
-/datum/job/judge
-	title = "Judge"
-	flag = JUDGE
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the city supervisor"
-	selection_color = "#515151"
-	idtype = /obj/item/weapon/card/id/civilian/judge
-	economic_modifier = 13
-	access = list(access_judge, access_sec_doors, access_maint_tunnels, access_heads)
-	minimal_access = list(access_judge, access_sec_doors, access_heads)
-	minimal_player_age = 7
-	minimum_character_age = 25
-	alt_titles = list("Magistrate")
-
-	outfit_type = /decl/hierarchy/outfit/job/judge
-
-
-/*
-/datum/job/lawyer/equip(var/mob/living/carbon/human/H)
-	. = ..()
-	if(.)
-		H.implant_loyalty(H)
-*/
-
-/datum/job/barber
+/datum/job/civilian/barber
 	title = "Barber"
 	flag = BARBER
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the city supervisor"
@@ -209,5 +157,5 @@
 	minimum_character_age = 18
 	access = list(access_barber, access_maint_tunnels)
 	minimal_access = list(access_barber)
-	outfit_type = /decl/hierarchy/outfit/job/barber
+	outfit_type = /decl/hierarchy/outfit/job/civilian/barber
 	alt_titles = list("Hairdresser", "Stylist", "Beautician")

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -1,10 +1,7 @@
 //Due to how large this one is it gets its own file
-/datum/job/chaplain
+/datum/job/civilian/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN
-	department = "Civilian"
-	department_flag = CIVILIAN
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	minimum_character_age = 18
@@ -15,9 +12,9 @@
 	minimal_access = list(access_chapel_office, access_crematorium)
 	alt_titles = list("Counselor", "Priest", "Preacher")
 
-	outfit_type = /decl/hierarchy/outfit/job/chaplain
+	outfit_type = /decl/hierarchy/outfit/job/civilian/chaplain
 
-/datum/job/chaplain/equip(var/mob/living/carbon/human/H, var/alt_title, var/ask_questions = TRUE)
+/datum/job/civilian/chaplain/equip(var/mob/living/carbon/human/H, var/alt_title, var/ask_questions = TRUE)
 	. = ..()
 	if(!.)
 		return
@@ -150,5 +147,5 @@
 		feedback_set_details("religion_book","[new_book_style]")
 	return 1
 
-/datum/job/chaplain/equip_preview(var/mob/living/carbon/human/H, var/alt_title)
+/datum/job/civilian/chaplain/equip_preview(var/mob/living/carbon/human/H, var/alt_title)
 	return equip(H, alt_title, FALSE)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -1,10 +1,13 @@
-/datum/job/chief_engineer
+/datum/job/engineering
+	department = "Engineering"
+	faction = "Station"
+// I should probably do something creative like making the /heads/ hierarchy completely dynamic so I can shove it wherever, but moving on.
+
+/datum/job/engineering/chief_engineer
 	title = "Chief Engineer"
 	flag = CHIEF
 	head_position = 1
-	department = "Engineering"
 	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Mayor"
@@ -29,12 +32,10 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
 
-/datum/job/engineer
+/datum/job/engineering/engineer
 	title = "City Engineer"
 	flag = ENGINEER
-	department = "Engineering"
 	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the chief engineer"
@@ -49,12 +50,10 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
 
-/datum/job/atmos
+/datum/job/engineering/atmos
 	title = "Firefighter"
 	flag = ATMOSTECH
-	department = "Engineering"
 	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 3
 	spawn_positions = 2
 	supervisors = "the chief engineer"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -1,8 +1,11 @@
-/datum/job/cmo
+/datum/job/medical // technically the access should all be merged up here too and cleaned up but w/e
+	department = "Medical"
+	department_flag = MEDSCI
+
+/datum/job/medical/cmo
 	title = "Chief Medical Officer"
 	flag = CMO
 	head_position = 1
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 1
@@ -27,10 +30,9 @@
 	alt_titles = list(
 		"Chief of Medicine")
 
-/datum/job/doctor
+/datum/job/medical/doctor
 	title = "Doctor"
 	flag = DOCTOR
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 5
@@ -49,11 +51,10 @@
 		"Nurse" = /decl/hierarchy/outfit/job/medical/doctor/nurse,
 		"Virologist" = /decl/hierarchy/outfit/job/medical/doctor/virologist)
 
-//Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
-/datum/job/chemist
+//Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro // Chemistry does more actual science than RnD at this point. But I'm glad you took time to bicker about which file it should go in instead of properly organizing the parenting. - Nappist
+/datum/job/medical/chemist
 	title = "Chemist"
 	flag = CHEMIST
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
@@ -71,10 +72,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 
-/datum/job/geneticist
+/datum/job/medical/geneticist
 	title = "Geneticist"
 	flag = GENETICIST
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 0
@@ -89,10 +89,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/geneticist
 
 
-/datum/job/psychiatrist
+/datum/job/medical/psychiatrist
 	title = "Psychiatrist"
 	flag = PSYCHIATRIST
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 1
@@ -106,10 +105,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
 	alt_titles = list("Psychologist" = /decl/hierarchy/outfit/job/medical/psychiatrist/psychologist)
 
-/datum/job/paramedic
+/datum/job/medical/paramedic
 	title = "Paramedic"
 	flag = PARAMEDIC
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -1,10 +1,12 @@
-/datum/job/rd
-	title = "Research Director"
-	flag = RD
-	head_position = 1
+/datum/job/science
 	department = "Science"
 	department_flag = MEDSCI
 	faction = "Station"
+
+/datum/job/science/rd
+	title = "Research Director"
+	flag = RD
+	head_position = 1
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the mayor"
@@ -28,12 +30,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	alt_titles = list("Research Supervisor")
 
-/datum/job/scientist
+/datum/job/science/scientist
 	title = "Scientist"
 	flag = SCIENTIST
-	department = "Science"
-	department_flag = MEDSCI
-	faction = "Station"
 	total_positions = 5
 	spawn_positions = 3
 	supervisors = "the research director"
@@ -48,12 +47,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 	alt_titles = list("Xenoarchaeologist", "Anomalist", "Phoron Researcher")
 
-/datum/job/xenobiologist
+/datum/job/science/xenobiologist
 	title = "Xenobiologist"
 	flag = XENOBIOLOGIST
-	department = "Science"
-	department_flag = MEDSCI
-	faction = "Station"
 	total_positions = 3
 	spawn_positions = 2
 	supervisors = "the research director"
@@ -68,12 +64,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	alt_titles = list("Xenobotanist")
 
-/datum/job/roboticist
+/datum/job/science/roboticist
 	title = "Roboticist"
 	flag = ROBOTICIST
-	department = "Science"
-	department_flag = MEDSCI
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "research director"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -1,10 +1,12 @@
-/datum/job/hos
-	title = "Chief of Police"
-	flag = HOS
-	head_position = 1
+/datum/job/security
 	department = "Security"
 	department_flag = ENGSEC
 	faction = "Station"
+
+/datum/job/security/hos
+	title = "Chief of Police"
+	flag = HOS
+	head_position = 1
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Mayor"
@@ -24,12 +26,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 	alt_titles = list("Security Commander", "Chief of Security")
 
-/datum/job/warden
+/datum/job/security/warden
 	title = "Prison Warden"
 	flag = WARDEN
-	department = "Security"
-	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the chief of police"
@@ -43,12 +42,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
 	alt_titles = list("Correctional Officer")
 
-/datum/job/detective
+/datum/job/security/detective
 	title = "Detective"
 	flag = DETECTIVE
-	department = "Security"
-	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the chief of police"
@@ -62,12 +58,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	alt_titles = list("Forensic Technician" = /decl/hierarchy/outfit/job/security/detective/forensic, "Investigator")
 
-/datum/job/officer
+/datum/job/security/officer
 	title = "Police Officer"
 	flag = OFFICER
-	department = "Security"
-	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 8
 	spawn_positions = 8
 	supervisors = "the chief of police"
@@ -81,12 +74,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
 	alt_titles = list("Junior Officer","Traffic Warden" = /decl/hierarchy/outfit/job/security/traffic)
 
-/datum/job/prosecutor
+/datum/job/security/prosecutor
 	title = "District Prosecutor"
 	flag = PROSECUTOR
-	department = "Security"
-	department_flag = ENGSEC
-	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the chief of police and city supervisor"

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -134,12 +134,12 @@
 /obj/item/weapon/card/id/silver/secretary
 	assignment = "City Hall Guard"
 	rank = "City Hall Guard"
-	job_access_type = /datum/job/secretary
+	job_access_type = /datum/job/heads/secretary
 
 /obj/item/weapon/card/id/silver/hop
 	assignment = "City Supervisor"
 	rank = "City Supervisor"
-	job_access_type = /datum/job/hop
+	job_access_type = /datum/job/heads/hop
 
 /obj/item/weapon/card/id/gold
 	name = "identification card"
@@ -151,13 +151,13 @@
 /obj/item/weapon/card/id/gold/captain
 	assignment = "Mayor"
 	rank = "Mayor"
-	job_access_type = /datum/job/captain
+	job_access_type = /datum/job/heads/captain
 
 /obj/item/weapon/card/id/gold/captain/spare
 	name = "\improper Mayor's spare ID"
 	desc = "The spare ID of the High Lord himself."
 	registered_name = "Mayor"
-	job_access_type = /datum/job/captain
+	job_access_type = /datum/job/heads/captain
 
 /obj/item/weapon/card/id/synthetic
 	name = "\improper Synthetic ID"
@@ -209,27 +209,27 @@
 /obj/item/weapon/card/id/medical/doctor
 	assignment = "Doctor"
 	rank = "Doctor"
-	job_access_type = /datum/job/doctor
+	job_access_type = /datum/job/medical/doctor
 
 /obj/item/weapon/card/id/medical/chemist
 	assignment = "Chemist"
 	rank = "Chemist"
-	job_access_type = /datum/job/chemist
+	job_access_type = /datum/job/medical/chemist
 
 /obj/item/weapon/card/id/medical/geneticist
 	assignment = "Geneticist"
 	rank = "Geneticist"
-	job_access_type = /datum/job/doctor	//geneticist
+	job_access_type = /datum/job/medical/doctor	//geneticist
 
 /obj/item/weapon/card/id/medical/psychiatrist
 	assignment = "Psychiatrist"
 	rank = "Psychiatrist"
-	job_access_type = /datum/job/psychiatrist
+	job_access_type = /datum/job/medical/psychiatrist
 
 /obj/item/weapon/card/id/medical/paramedic
 	assignment = "Paramedic"
 	rank = "Paramedic"
-	job_access_type = /datum/job/paramedic
+	job_access_type = /datum/job/medical/paramedic
 
 /obj/item/weapon/card/id/medical/head
 	name = "identification card"
@@ -239,7 +239,7 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Chief Medical Officer"
 	rank = "Chief Medical Officer"
-	job_access_type = /datum/job/cmo
+	job_access_type = /datum/job/medical/cmo
 
 /obj/item/weapon/card/id/security
 	name = "identification card"
@@ -251,17 +251,17 @@
 /obj/item/weapon/card/id/security/officer
 	assignment = "Police Officer"
 	rank = "Police Officer"
-	job_access_type = /datum/job/officer
+	job_access_type = /datum/job/security/officer
 
 /obj/item/weapon/card/id/security/detective
 	assignment = "Detective"
 	rank = "Detective"
-	job_access_type = /datum/job/detective
+	job_access_type = /datum/job/security/detective
 
 /obj/item/weapon/card/id/security/warden
 	assignment = "Prison Warden"
 	rank = "Prison Warden"
-	job_access_type = /datum/job/warden
+	job_access_type = /datum/job/security/warden
 
 /obj/item/weapon/card/id/security/head
 	name = "identification card"
@@ -271,7 +271,7 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Chief of Police"
 	rank = "Chief of Police"
-	job_access_type = /datum/job/hos
+	job_access_type = /datum/job/security/hos
 
 /obj/item/weapon/card/id/engineering
 	name = "identification card"
@@ -283,12 +283,12 @@
 /obj/item/weapon/card/id/engineering/engineer
 	assignment = "City Engineer"
 	rank = "City Engineer"
-	job_access_type = /datum/job/engineer
+	job_access_type = /datum/job/engineering/engineer
 
 /obj/item/weapon/card/id/engineering/atmos
 	assignment = "Firefighter"
 	rank = "Firefighter"
-	job_access_type = /datum/job/atmos
+	job_access_type = /datum/job/engineering/atmos
 
 /obj/item/weapon/card/id/engineering/head
 	name = "identification card"
@@ -298,7 +298,7 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Chief Engineer"
 	rank = "Chief Engineer"
-	job_access_type = /datum/job/chief_engineer
+	job_access_type = /datum/job/engineering/chief_engineer
 
 /obj/item/weapon/card/id/science
 	name = "identification card"
@@ -310,17 +310,17 @@
 /obj/item/weapon/card/id/science/scientist
 	assignment = "Scientist"
 	rank = "Scientist"
-	job_access_type = /datum/job/scientist
+	job_access_type = /datum/job/science/scientist
 
 /obj/item/weapon/card/id/science/xenobiologist
 	assignment = "Xenobiologist"
 	rank = "Xenobiologist"
-	job_access_type = /datum/job/xenobiologist
+	job_access_type = /datum/job/science/xenobiologist
 
 /obj/item/weapon/card/id/science/roboticist
 	assignment = "Roboticist"
 	rank = "Roboticist"
-	job_access_type = /datum/job/roboticist
+	job_access_type = /datum/job/science/roboticist
 
 /obj/item/weapon/card/id/science/head
 	name = "identification card"
@@ -330,7 +330,7 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Research Director"
 	rank = "Research Director"
-	job_access_type = /datum/job/rd
+	job_access_type = /datum/job/science/rd
 
 /obj/item/weapon/card/id/cargo
 	name = "identification card"
@@ -342,12 +342,12 @@
 /obj/item/weapon/card/id/cargo/cargo_tech
 	assignment = "Factory Worker"
 	rank = "Factory Worker"
-	job_access_type = /datum/job/cargo_tech
+	job_access_type = /datum/job/civilian/cargo_tech
 
 /obj/item/weapon/card/id/cargo/mining
 	assignment = "Miner"
 	rank = "Miner"
-	job_access_type = /datum/job/mining
+	job_access_type = /datum/job/civilian/mining
 
 /obj/item/weapon/card/id/cargo/head
 	name = "identification card"
@@ -357,7 +357,7 @@
 	secondary_color = rgb(255,223,127)
 	assignment = "Factory Manager"
 	rank = "Factory Manager"
-	job_access_type = /datum/job/qm
+	job_access_type = /datum/job/civilian/qm
 
 /obj/item/weapon/card/id/assistant
 	assignment = "Civilian"
@@ -377,52 +377,52 @@
 /obj/item/weapon/card/id/civilian/bartender
 	assignment = "Bartender"
 	rank = "Bartender"
-	job_access_type = /datum/job/bartender
+	job_access_type = /datum/job/civilian/bartender
 
 /obj/item/weapon/card/id/civilian/botanist
 	assignment = "Botanist"
 	rank = "Botanist"
-	job_access_type = /datum/job/hydro
+	job_access_type = /datum/job/civilian/hydro
 
 /obj/item/weapon/card/id/civilian/chaplain
 	assignment = "Chaplain"
 	rank = "Chaplain"
-	job_access_type = /datum/job/chaplain
+	job_access_type = /datum/job/civilian/chaplain
 
 /obj/item/weapon/card/id/civilian/chef
 	assignment = "Chef"
 	rank = "Chef"
-	job_access_type = /datum/job/chef
+	job_access_type = /datum/job/civilian/chef
 
-/obj/item/weapon/card/id/civilian/judge
+/obj/item/weapon/card/id/heads/judge
 	assignment = "Judge"
 	rank = "Judge"
-	job_access_type = /datum/job/judge
+	job_access_type = /datum/job/heads/judge
 
 /obj/item/weapon/card/id/security/prosecutor
 	assignment = "District Prosecutor"
 	rank = "District Prosecutor"
-	job_access_type = /datum/job/prosecutor
+	job_access_type = /datum/job/security/prosecutor
 
 /obj/item/weapon/card/id/civilian/defense
 	assignment = "Defense Attorney"
 	rank = "Defense Attorney"
-	job_access_type = /datum/job/defense
+	job_access_type = /datum/job/civilain/defense
 
 /obj/item/weapon/card/id/civilian/barber
 	assignment = "Barber"
 	rank = "Barber"
-	job_access_type = /datum/job/barber
+	job_access_type = /datum/job/civilian/barber
 
 /obj/item/weapon/card/id/civilian/janitor
 	assignment = "Janitor"
 	rank = "Janitor"
-	job_access_type = /datum/job/janitor
+	job_access_type = /datum/job/civilian/janitor
 
 /obj/item/weapon/card/id/civilian/librarian
 	assignment = "Librarian"
 	rank = "Librarian"
-	job_access_type = /datum/job/librarian
+	job_access_type = /datum/job/civilian/librarian
 
 /obj/item/weapon/card/id/civilian/head //This is not the HoP. There's no position that uses this right now.
 	name = "identification card"

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -407,7 +407,7 @@
 /obj/item/weapon/card/id/civilian/defense
 	assignment = "Defense Attorney"
 	rank = "Defense Attorney"
-	job_access_type = /datum/job/civilain/defense
+	job_access_type = /datum/job/civilian/defense
 
 /obj/item/weapon/card/id/civilian/barber
 	assignment = "Barber"

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -22,7 +22,7 @@ var/const/access_explorer = 43
 /obj/item/weapon/card/id/medical/sar
 	assignment = "Search and Rescue"
 	rank = "Search and Rescue"
-	job_access_type = /datum/job/sar
+	job_access_type = /datum/job/medical/sar
 
 /obj/item/weapon/card/id/civilian/pilot
 	assignment = "Pilot"
@@ -40,7 +40,7 @@ var/const/access_explorer = 43
 
 //Will see about getting working later.
 
-/datum/job/captain
+/datum/job/heads/captain
 	title = "Station Director"
 	flag = CAPTAIN
 	department = "Command"
@@ -61,10 +61,10 @@ var/const/access_explorer = 43
 	minimum_character_age = 25
 	ideal_character_age = 50 // Because 70 is a tad on the old side
 
-	outfit_type = /decl/hierarchy/outfit/job/captain
+	outfit_type = /decl/hierarchy/outfit/job/heads/captain
 	alt_titles = list("Site Manager", "Overseer")
 
-/datum/job/captain/get_access()
+/datum/job/heads/captain/get_access()
 	return get_all_station_access()
 */
 
@@ -105,10 +105,9 @@ var/const/access_explorer = 43
 		"Explorer Medic" = /decl/hierarchy/outfit/job/explorer2/medic)
 */
 
-/datum/job/sar
+/datum/job/medical/sar
 	title = "Search and Rescue"
 	flag = SAR
-	department = "Medical"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2


### PR DESCRIPTION
Adds a parent to jobs. Can probably be compressed and deleted further - makes it easier for organization, or in the case of game modes, slotting all of a type of job as allowed/denied/kill etc.

Needs more cleanup in terms of sorting code into the parent to reduce copypasta.

Needs to have /heads/ be made dynamic so it can be applied as such.