### PR TITLE
Janitor/Judge Accuracy Fixes

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -102,7 +102,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	flag = JUDGE
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the city supervisor"
+	supervisors = "government officials and the President"
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/heads/judge
 	economic_modifier = 13

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -101,7 +101,7 @@
 
 //Service
 /datum/job/civilian/janitor
-	title = "Janitor"
+	title = "Sanitation Technician"
 	flag = JANITOR
 	total_positions = 2
 	spawn_positions = 2
@@ -112,7 +112,7 @@
 	minimal_access = list(access_janitor, access_maint_tunnels)
 	minimum_character_age = 18
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
-	alt_titles = list("Custodian", "Sanitation Technician")
+	alt_titles = list("Recycling Technician", "Sanitation Engineer")
 
 //More or less assistants
 /datum/job/civilian/librarian

--- a/html/changelogs/XanderDox - Janitor.yml
+++ b/html/changelogs/XanderDox - Janitor.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: XanderDox
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Janitor has been renamed to 'Sanitation Technician' and given new alt-titles."	


### PR DESCRIPTION
Replaces 'Janitor' with 'Sanitation Technician and adds the following titles:
- Recycling Technician
- Sanitation Engineer.

These are more city-oriented titles.

Changes the Judge's supervisor from the City Clerk, to 'government officials and the President' like the mayor, as the Judge does not answer to city officials like the Mayor or Clerk as they are the head of the local judiciary.