### PR TITLE
Prevents people from joining with the same name

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -222,6 +222,12 @@
 		ViewManifest()
 
 	if(href_list["SelectedJob"])
+	
+		for (var/mob/living/carbon/human/C in mob_list)
+		    var/char_name = client.prefs.real_name
+		    if(char_name == C.real_name)
+			usr << "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>"
+			return
 
 		if(!config.enter_allowed)
 			usr << "<span class='notice'>There is an administrative lock on entering the game!</span>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -222,12 +222,12 @@
 		ViewManifest()
 
 	if(href_list["SelectedJob"])
-	
+		//Prevents people rejoining as same character.
 		for (var/mob/living/carbon/human/C in mob_list)
-		    var/char_name = client.prefs.real_name
-		    if(char_name == C.real_name)
-			usr << "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>"
-			return
+			var/char_name = client.prefs.real_name
+			if(char_name == C.real_name)
+				usr << "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>"
+				return
 
 		if(!config.enter_allowed)
 			usr << "<span class='notice'>There is an administrative lock on entering the game!</span>"


### PR DESCRIPTION
Due to many issues with people joining as the same character after they respawn, this code will stop them from joining as the same character. This won't prevent metagaming, but is a good step.