### PR TITLE
Reduces handcuffing time

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -17,7 +17,7 @@
 	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
 	var/cuff_sound = 'sound/weapons/handcuffs.ogg'
 	var/cuff_type = "handcuffs"
-	var/use_time = 30
+	var/use_time = 5 // short stuns, faster cuffing
 	sprite_sheets = list(SPECIES_TESHARI = 'icons/mob/species/seromi/handcuffs.dmi')
 
 /obj/item/weapon/handcuffs/get_worn_icon_state(var/slot_name)
@@ -147,6 +147,7 @@ var/last_chew = 0
 	cuff_sound = 'sound/weapons/cablecuff.ogg'
 	cuff_type = "cable restraints"
 	elastic = 1
+	use_time = 30 // cables are fiddly.
 
 /obj/item/weapon/handcuffs/cable/red
 	color = "#DD0000"


### PR DESCRIPTION
* Cable cuffs are kept to the same cuff time.
* Regular hand cuffs go on with a very short time (2 seconds).

To go hand in hand with short stuns. You've still got to grab the person, however.