### PR TITLE
Minimum Player Age Requirements

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -105,13 +105,14 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	total_positions = 1
 	spawn_positions = 1
 	department_flag = CIVILIAN
+	req_admin_notify = 1
 	supervisors = "government officials and the President"
 	selection_color = "#1D1D4F"
 	idtype = /obj/item/weapon/card/id/heads/judge
 	economic_modifier = 13
 	access = list(access_judge, access_warrant, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_judge, access_warrant, access_sec_doors, access_heads)
-	minimal_player_age = 7
+//	minimal_player_age = 7 (need more judges)
 	minimum_character_age = 25
 	alt_titles = list("Magistrate")
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -100,13 +100,14 @@
 	department = "Civilian"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "yourself"
+	supervisors = "the Judge"
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/defense
 	economic_modifier = 7
+	req_admin_notify = 1
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
-	minimal_player_age = 7
+//	minimal_player_age = 7 (More lawyers please.)
 	minimum_character_age = 20
 	alt_titles = list("Defense Lawyer","Defense Attorney","Barrister")
 
@@ -139,7 +140,7 @@
 	faction = "City"
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "the Mayor and the City Clerk"
+	supervisors = "the Mayor and the City Council"
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/secretary
 	economic_modifier = 1

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -58,7 +58,7 @@
 	faction = "City"
 	total_positions = 2
 	spawn_positions = 2
-	minimum_character_age = 23
+	minimum_character_age = 25
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/chemist
@@ -97,7 +97,7 @@
 	total_positions = 4
 	spawn_positions = 1
 	economic_modifier = 5
-	minimum_character_age = 20
+	minimum_character_age = 25
 	supervisors = "the chief medical officer"
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/psychiatrist
@@ -135,7 +135,7 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/intern
 	economic_modifier = 1
-	minimum_character_age = 13
+	minimum_character_age = 18 //Excuse me electric, what.
 	access = list(access_medical)
 	minimal_access = list(access_medical, access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/medical/intern

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -43,7 +43,7 @@
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
 	minimum_character_age = 20
-	minimal_player_age = 3
+//	minimal_player_age = 3
 
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 	alt_titles = list("Xenoarchaeologist", "Anomalist", "Phoron Researcher")
@@ -63,7 +63,7 @@
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_hydroponics)
 	minimal_access = list(access_research, access_xenobiology, access_hydroponics, access_tox_storage)
 	minimum_character_age = 20
-	minimal_player_age = 3
+//	minimal_player_age = 3
 
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	alt_titles = list("Xenobotanist")
@@ -83,7 +83,7 @@
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimum_character_age = 20
-	minimal_player_age = 3
+//	minimal_player_age = 3
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer","Car Engineer")

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -92,13 +92,14 @@
 	department_flag = ENGSEC
 	total_positions = 1
 	spawn_positions = 1
+	req_admin_notify = 1
 	supervisors = "the chief of police and city clerk"
 	selection_color = "#601C1C"
 	idtype = /obj/item/weapon/card/id/security/prosecutor
 	economic_modifier = 7
 	access = list(access_prosecutor, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_prosecutor, access_sec_doors, access_heads)
-	minimal_player_age = 7
+//	minimal_player_age = 7 (need more prostitut-- prosecutors.)
 	minimum_character_age = 21
 	alt_titles = list("Prosecutor","Prosecuting Attorney","Prosecution Officer","Prosecuting Lawyer")
 


### PR DESCRIPTION
Removes timelock for defense lawyer and prosecutor roles. Sets judge timelock to 1 day.

Also removes timelock on science department. Increases (character) ages on medical staff to 25 (kept CMO to 30). 