### PR TITLE
Nerfs Zombies

### DIFF
--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -8,5 +8,5 @@
 	required_players_secret = 1
 	required_enemies = 1
 	end_on_antag_death = 1
-	restricted_jobs = list("AI", "Cyborg","Chief Medical Officer", "Doctor", "Virologist")
-	votable = 0 //Until this mode is fixed.
+	restricted_jobs = list("AI", "Cyborg","Chief Medical Officer", "Doctor", "Virologist", "Chief of Police", "Police Officer")
+	votable = 0 // Maaaaybe see how the nerfs go first.

--- a/code/modules/mob/living/carbon/zombie/evolutions/zombie_evolutions.dm
+++ b/code/modules/mob/living/carbon/zombie/evolutions/zombie_evolutions.dm
@@ -14,7 +14,7 @@
 	evolution = TANKER_EVOLUTION
 	mob_size = MOB_LARGE
 	death_message = "Makes a loud whistling sound as it emits a foul odourous gas into the air..."
-	slowdown = 1.2 //A bit slower than a regular zombie...
+	slowdown = 2.2 //A bit slower than a regular zombie...
 	total_health = 300 //thicc
 	brute_mod = 0.30 //Have you ever hit a huge bag of pudding and watched it jiggle? Yeah that.
 	icobase = 'icons/mob/human_races/r_zombie_tanker.dmi'

--- a/code/modules/mob/living/carbon/zombie/zombie_abilities.dm
+++ b/code/modules/mob/living/carbon/zombie/zombie_abilities.dm
@@ -19,44 +19,48 @@
 			C.visible_message("<span class='warning'>\The [C]'s entire form seems to twitch in a very unsettling way.</span>")
 
 
-			do_after(C, 2100)
+			if(do_after(C, 2100))
 
-			C.tod = null
-			C.setToxLoss(0)
-			C.setOxyLoss(0)
-			C.setCloneLoss(0)
-			C.SetParalysis(0)
-			C.SetStunned(0)
-			C.SetWeakened(0)
-			C.radiation = 0
-			C.heal_overall_damage(C.getBruteLoss(), C.getFireLoss())
-			C.reagents.clear_reagents()
-			if(ishuman(C))
-				var/mob/living/carbon/human/H = src
-				H.species.create_organs(H)
-				H.restore_all_organs(ignore_prosthetic_prefs=1) //Covers things like fractures and other things not covered by the above.
-				H.restore_blood()
-				H.mutations.Remove(HUSK)
-				H.status_flags &= ~DISFIGURED
-				H.update_icons_body()
-				for(var/limb in H.organs_by_name)
-					var/obj/item/organ/external/current_limb = H.organs_by_name[limb]
-					if(current_limb)
-						current_limb.relocate()
-						current_limb.open = 0
+				C.tod = null
+				C.setToxLoss(0)
+				C.setOxyLoss(0)
+				C.setCloneLoss(0)
+				C.SetParalysis(0)
+				C.SetStunned(0)
+				C.SetWeakened(0)
+				C.radiation = 0
+				C.heal_overall_damage(C.getBruteLoss(), C.getFireLoss())
+				C.reagents.clear_reagents()
+				if(ishuman(C))
+					var/mob/living/carbon/human/H = src
+					H.species.create_organs(H)
+					H.restore_all_organs(ignore_prosthetic_prefs=1) //Covers things like fractures and other things not covered by the above.
+					H.restore_blood()
+					H.mutations.Remove(HUSK)
+					H.status_flags &= ~DISFIGURED
+					H.update_icons_body()
+					for(var/limb in H.organs_by_name)
+						var/obj/item/organ/external/current_limb = H.organs_by_name[limb]
+						if(current_limb)
+							current_limb.relocate()
+							current_limb.open = 0
 
-				BITSET(H.hud_updateflag, HEALTH_HUD)
-				BITSET(H.hud_updateflag, STATUS_HUD)
-				BITSET(H.hud_updateflag, LIFE_HUD)
+					BITSET(H.hud_updateflag, HEALTH_HUD)
+					BITSET(H.hud_updateflag, STATUS_HUD)
+					BITSET(H.hud_updateflag, LIFE_HUD)
 
-			C.halloss = 0
-			C.shock_stage = 0 //Pain
-			C << "<span class='notice'>You rise from the dead.</span>"
-			C.update_canmove()
-			C.stat = CONSCIOUS
-			C.forbid_seeing_deadchat = FALSE
-			C.timeofdeath = null
-			return 1
+
+					C.halloss = 0
+					C.shock_stage = 0 //Pain
+					C << "<span class='notice'>You rise from the dead.</span>"
+					C.update_canmove()
+					C.stat = CONSCIOUS
+					C.forbid_seeing_deadchat = FALSE
+					C.timeofdeath = null
+					return 1
+			else
+				C << "<span class='notice'>Your vessel is interrupted.</span>"
+
 	else
 		C << "<span class='alium'>You can only use this while dead.</span>"
 		return

--- a/code/modules/mob/living/carbon/zombie/zombie_species.dm
+++ b/code/modules/mob/living/carbon/zombie/zombie_species.dm
@@ -40,7 +40,7 @@
 	spawn_flags = SPECIES_IS_RESTRICTED
 	show_ssd = null
 	virus_immune = 1
-	brute_mod = 0.25
+	brute_mod = 2
 	burn_mod = 2
 	speech_chance  = 80
 	speech_sounds = list('sound/voice/zombie_groan.ogg')
@@ -54,7 +54,7 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 //	hud_type = /datum/hud_data/zombie
-	slowdown = 1 //zombies are slow as fuck
+	slowdown = 1.5 //zombies are slow as fuck
 	can_drive = 0
 
 	has_fine_manipulation = FALSE
@@ -68,8 +68,8 @@
 
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/proc/tackle,
-		/mob/living/carbon/human/proc/gut,
+//		/mob/living/carbon/human/proc/tackle,
+//		/mob/living/carbon/human/proc/gut,
 		/mob/living/carbon/human/proc/revive_undead,
 		/mob/living/carbon/human/proc/fermented_goo
 


### PR DESCRIPTION
- Removes gut and tackle ability
- Makes them more suseptible to brute damage (as much as lasers). Twice as susceptible.
- Slows them down
- Fixes the revival glitch that makes zombies instantly revive if removed.

If ya'll can't beat zombos after this, you're just unrobust mmkay.