### PR TITLE
Fixes AIs spawning on top of each other

### DIFF
--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -20,6 +20,8 @@ var/datum/antagonist/rogue_ai/malf
 /datum/antagonist/rogue_ai/New()
 	..()
 	malf = src
+	job_master.AssignRole(src, "AI", 0)
+
 
 
 /datum/antagonist/rogue_ai/get_candidates()


### PR DESCRIPTION
During malf rounds, a non-rogue AI would spawn on top of the malf AI and completely ruin the round. I believe the game doesn't register the malf AI to the AI job. 

This should fix this.