### PR TITLE
[Bay Port] Adds Cross-Round Trash Persistence

### DIFF
--- a/code/controllers/subsystems/initialization/persistence.dm
+++ b/code/controllers/subsystems/initialization/persistence.dm
@@ -1,0 +1,28 @@
+SUBSYSTEM_DEF(persistence)
+	name = "Persistence"
+	init_order = SS_INIT_MISC_LATE
+	flags = SS_NO_FIRE
+	var/list/tracking_values = list()
+	var/list/persistence_datums = list()
+
+/datum/controller/subsystem/persistence/Initialize()
+	. = ..()
+	for(var/thing in subtypesof(/datum/persistent))
+		var/datum/persistent/P = new thing
+		persistence_datums[thing] = P
+		P.Initialize()
+
+/datum/controller/subsystem/persistence/Shutdown()
+	for(var/thing in persistence_datums)
+		var/datum/persistent/P = persistence_datums[thing]
+		P.Shutdown()
+
+/datum/controller/subsystem/persistence/proc/track_value(var/atom/value, var/track_type)
+	if((value.z in GLOB.using_map.station_levels) && initialized)
+		if(!tracking_values[track_type])
+			tracking_values[track_type] = list()
+		tracking_values[track_type] += value
+
+/datum/controller/subsystem/persistence/proc/forget_value(var/atom/value, var/track_type)
+	if(tracking_values[track_type])
+		tracking_values[track_type] -= value


### PR DESCRIPTION
**MistakeNot4892:**
> This ended up being a bit of a fey mood.
> 
> * Adds the ability to scratch graffiti into most turfs with sharp objects. Graffiti, like wall rot/mold, is removed with a welding torch because spacemans.
> * Screwdrivers are now sharp.
> * Adds a subsystem that controls loading and saving various persistent objects between rounds using a datum system.
> * Currently the system handles general filth (blood, vomit, dirt) via a generic 'filth' decal to avoid 'oh my god the toilets are full of blood', trash items, and graffiti.
> * It will only handle things created during the round (post init) on the station Z level.
> * The persistent entries will decay after five rounds for garbage/filth, and fifty rounds (roughly a week) for graffiti. After 25 rounds, graffiti will also start to degrade.
> * Cigarette butts have been repathed to trash.

