### PR TITLE
Update water.dm

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -11,11 +11,13 @@
 	outdoors = TRUE
 	var/depth = 1 // Higher numbers indicates deeper water.
 	initial_flooring = /decl/flooring/water
-
+	light_color = "#add8e6"
+	light_range = 2
 
 /turf/simulated/floor/water/initialize()
 	. = ..()
 	update_icon()
+	set_light(2, 1, "#add8e6")
 
 /turf/simulated/floor/water/update_icon()
 	..() // To get the edges.


### PR DESCRIPTION
For whatever reason it uses the set_light proc, probably because it processes the atoms to datums and lists and faffs about with this; be careful, setting the lighting on the turfs themselves is very server-intensive especially over large areas.

There's probably something wrong with set_light not init not calling on the vars of the item itself.

The lighting for this sucks you may want to change it.

lighting_atom.dm is what you want to look at for the origin of this proc