### PR TITLE
Fixes Bank Payroll Messages being repeated

### DIFF
--- a/code/controllers/subsystems/economy.dm
+++ b/code/controllers/subsystems/economy.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(economy)
 		//Search general records, and process payroll for all those that have bank numbers.
 		for(var/datum/data/record/R in data_core.general)
 			payroll(R)
-			command_announcement.Announce("Hourly payroll has been processed. Please check your bank accounts for your latest payment.", "Payroll")
+		command_announcement.Announce("Hourly payroll has been processed. Please check your bank accounts for your latest payment.", "Payroll")
 
 
 /proc/payroll(var/datum/data/record/G)


### PR DESCRIPTION
This is why double-checking indentation is important, folks.

"You have been paid."
"You have been paid."
"You have been paid."
"You have been paid."
"You have been paid."

Watching all those excited people check their payroll for duplicate money and finding it was just the message that was duplicated was quite funny!