### PR TITLE
Stops graffiti, trash, and notices from saving during non-canon rounds

### DIFF
--- a/code/controllers/subsystems/initialization/persistence.dm
+++ b/code/controllers/subsystems/initialization/persistence.dm
@@ -18,6 +18,10 @@ SUBSYSTEM_DEF(persistence)
 		P.Shutdown()
 
 /datum/controller/subsystem/persistence/proc/track_value(var/atom/value, var/track_type)
+
+	if(config.canonicity) //if we're not canon in config or by gamemode, nothing will save.
+		return
+		
 	var/turf/T = get_turf(value)
 	if(!T)
 		return


### PR DESCRIPTION
Title.