### PR TITLE
Adds several new jobs + titles + NT job access fix

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -19,6 +19,8 @@
 					"Expat",
 					"Asylum Seeker",
 					"Migrant",
+					"Socialite",
+					"Job Seeker",
 					"Traveller",
 					"Unemployed",
 					"Homeless",

--- a/code/game/jobs/job/hospital.dm
+++ b/code/game/jobs/job/hospital.dm
@@ -42,14 +42,13 @@
 	idtype = /obj/item/weapon/card/id/medical/doctor
 	wage = 80
 	minimum_character_age = 25
-	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
+	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_virology, access_eva)
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 	alt_titles = list(
 		"Surgeon" = /decl/hierarchy/outfit/job/medical/doctor/surgeon,
 		"Emergency Physician" = /decl/hierarchy/outfit/job/medical/doctor/emergency_physician,
-		"Nurse" = /decl/hierarchy/outfit/job/medical/doctor/nurse,
-		"Virologist" = /decl/hierarchy/outfit/job/medical/doctor/virologist)
+		"Nurse" = /decl/hierarchy/outfit/job/medical/doctor/nurse)
 
 //Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro // Chemistry does more actual science than RnD at this point. But I'm glad you took time to bicker about which file it should go in instead of properly organizing the parenting. - Nappist
 /datum/job/chemist
@@ -66,7 +65,7 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/chemist
 	wage = 60
-	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
+	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology)
 	minimal_access = list(access_medical, access_medical_equip, access_chemistry)
 	alt_titles = list("Pharmacist")
 
@@ -74,21 +73,22 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 
-/*/datum/job/geneticist
+/datum/job/geneticist
 	title = "Geneticist"
 	flag = GENETICIST
+	department = "Public Healthcare"
 	department_flag = MEDSCI
 	faction = "City"
 	total_positions = 0
 	spawn_positions = 0
-	supervisors = "the chief medical officer"
+	supervisors = "your private company director"
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/geneticist
 	wage = 7
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
+	access = list(access_genetics)
+	minimal_access = list(access_genetics)
 
-	outfit_type = /decl/hierarchy/outfit/job/medical/geneticist */
+	outfit_type = /decl/hierarchy/outfit/job/medical/geneticist
 
 
 /datum/job/psychiatrist

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -23,7 +23,7 @@
 	minimal_player_age = 14
 
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
-	alt_titles = list("Head of Police", "Police Commander", "Police Commissioner")
+	alt_titles = list("Head of Police", "Police Commander", "Police Commissioner", "Police Chief")
 
 /datum/job/warden
 	title = "Prison Warden"
@@ -44,7 +44,7 @@
 	minimum_character_age = 28
 
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
-	alt_titles = list("Correctional Officer")
+	alt_titles = list("Correctional Officer", "Brig Attendant")
 
 /datum/job/detective
 	title = "Detective"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -13,11 +13,11 @@
 	idtype = /obj/item/weapon/card/id/science/head
 	req_admin_notify = 1
 	wage = 490
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	access = list(access_rd, access_heads, access_tox, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
-	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	minimal_access = list(access_rd, access_heads, access_tox, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -102,7 +102,7 @@
 	faction = "City"
 	department_flag = CIVILIAN
 	department = "Civilian"
-	total_positions = 1
+	total_positions = 4
 	spawn_positions = 1
 	supervisors = "the Judge"
 	selection_color = "#515151"
@@ -114,7 +114,7 @@
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
 //	minimal_player_age = 7 (More lawyers please.)
 	minimum_character_age = 20
-	alt_titles = list("Defense Lawyer","Defense Attorney","Barrister")
+	alt_titles = list("Defense Lawyer","Defense Attorney","Barrister", "Legal Advisor")
 
 	outfit_type = /decl/hierarchy/outfit/job/civilian/defense/defense
 

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -197,20 +197,33 @@
 	icon_state = "nanotrasen"
 	registered_name = "Central Command"
 	assignment = "General"
-pref.money_balance
+	job_access_type = /datum/job/nanotrasen/cbia
 
 /obj/item/weapon/card/id/cbia/initialize()
 	. = ..()
-	access += get_all_centcom_access()
-	access += get_all_station_access()
+	access |= get_all_centcom_access()
+	access |= get_all_station_access()
 
 /obj/item/weapon/card/id/centcom/station/president
 	name = "\improper President's ID"
 	desc = "An ID that has both centcom and full city access."
+	job_access_type = /datum/job/nanotrasen/president
+
+/obj/item/weapon/card/id/centcom/station/president/initialize()
+	. = ..()
+	access |= get_all_centcom_access()
+	access |= get_all_station_access()
+
 
 /obj/item/weapon/card/id/centcom/station/ceo
 	name = "\improper NanoTrasen CEO's ID"
 	desc = "An ID that has both centcom and full city access."
+	job_access_type = /datum/job/nanotrasen/ceo
+
+/obj/item/weapon/card/id/centcom/station/ceo/initialize()
+	. = ..()
+	access |= get_all_centcom_access()
+	access |= get_all_station_access()
 
 /obj/item/weapon/card/id/centcom/ERT
 	name = "\improper Emergency Response Team ID"


### PR DESCRIPTION
- Adds Geneticist job back into the game. But it's private, so the CMO has no authority over them.
- Removes Virologist from doctor alt titles.
- Adds a few more alt titles for civilian, COP, and a few other jobs.

**Bonus:**
- NT Reps, president and CEO now have their access back, so they can waltz into your buildings and offer you bribes again.