### PR TITLE
Removes malf mode

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -10,4 +10,4 @@
 	auto_recall_shuttle = 0
 	antag_tags = list(MODE_MALFUNCTION)
 	disabled_jobs = list("AI")
-	votable = 1
+	votable = 0		// no more salt, jesus make it stop. i'm just tryna live :(


### PR DESCRIPTION
See guys, let me tell you a joke.

You got this... you got this gamemode right? It's a tale of a HRP server, and it literally tells a select group of players (AI and cyborgs) to kill the other players. Now what makes it juicy is, it can be either of these three states and will be one of them upon exist.

**Scenario 1:** AIs and cyborgs try to roleplay with the crew, acting suspicious. People have a legitimate reason to ask AI for laws and check them, and any self-protection AIs do to prevent cyborgs from being disabled blown, or disconnected would be a legit reason to have someone come to their core and instantly kill them. Making the AI players salty because bad RP.

**Scenario 2:** AI and cyborgs go stealth, they hack the APCs and act nice. Suddenly the station blows up. Wow. A non-persistent extended round ended with a boom. Everyone is happy, except for the humans. Boring as hell, terrible.

**Scenario 3:** AI and cyborgs follow their directives to the minimal letter. Knowing that the crew can arm up and kill them at any time, they decide to be the first to strike. Disable tcomms and murder as many as possible. Then blow shit up. Making the human players salty because bad RP.

**Scenario 4 (never happens):** Everyone is fair, humans don't raid AI core on the slightest sniff of antag and AI and cyborgs don't murderbone and everyone lives happily ever after.

![image](https://media1.tenor.com/images/ba46b4cdb30aa69eabf0191c9df15241/tenor.gif?itemid=9399227)

Yeah the meme was good guys, but the joke has to end someday. How this code stayed on HRP servers is a interesting feat, but anyone can go to our lovely /tg/ to play it no biggie. But yeah this is the only gamemode generating salt atm so i'm removing it. Thank you and have a good night everyone.