### PR TITLE
Fixes table layering and wall blocks

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -120,7 +120,7 @@
 	else
 		return ..()
 
-/obj/structure/proc/can_climb(var/mob/living/user, post_climb_check=0)
+/obj/structure/proc/can_climb(var/mob/living/user, post_climb_check=0) // this could probably include everything under the sun that would be a problem, including turf checks and other stuff. not sure why it's all spread out in different files or window checks.
 	if (!climbable || !can_touch(user) || (!post_climb_check && (user in climbers)))
 		return 0
 
@@ -136,7 +136,7 @@
 
 /obj/structure/proc/turf_is_crowded()
 	var/turf/T = get_turf(src)
-	if(!T || !istype(T))
+	if(!T || !istype(T) || istype(T, /turf/simulated/wall))
 		return 0
 	for(var/obj/O in T.contents)
 		if(istype(O,/obj/structure))

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 1
 	climbable = 1
-	layer = 2.8
+	layer = TABLE_LAYER
 	throwpass = 1
 	surgery_odds = 66
 	burn_state = 0 //Burnable


### PR DESCRIPTION
Makes it so you can't use low walls and climb through walls. Tables will still visually appear on top of walls, as will low walls, but you can no longer use them to climb *through* walls.

Changes the hardcoded number to the TABLE_LAYER define under tables for future reasons.

Has been tested.