### PR TITLE
Cleans up cryobags

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -70,11 +70,9 @@
 	contains_body = ..()
 	return contains_body
 
-/obj/structure/closet/body_bag/close()
-	if(..())
-		density = 0
-		return 1
-	return 0
+/obj/structure/closet/body_bag/openhelper()
+	..()
+	src.density = 0
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	..()
@@ -157,7 +155,7 @@
 	return ..()
 
 /obj/structure/closet/body_bag/cryobag/open()
-	. = ..()
+	..()
 	if(used && !reusable)
 		var/obj/item/O = new/obj/item(src.loc)
 		O.name = "used stasis bag"


### PR DESCRIPTION
Cryobags are two different things: One of them is the object and the other is a subtype of closets. When I cleaned up closet code, I failed to tackle cryobags, because they were in a completely different location.

This is why the file hierarchy needs to be arranged like the object hierarchy 99.99% of the time.

I can honestly say cryobag closet code was a lot cleaner than either closet or crate code.