### PR TITLE
Farmbot hacking again

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -172,7 +172,10 @@
 				busy = 1
 				if(do_after(src, 30, A))
 					visible_message("<span class='notice'>[src] [T.dead? "removes the plant from" : "harvests"] \the [A].</span>")
-					src.attack_hand(A) // the hydroponics tray can't attack itself. That would be silly. Neither is it capable of attacking the farmbot.
+					if(T.dead)
+						T.remove_dead(src) //attack_hand bugs out because the mob has no browser/client. /hydroponics/ has the proc built into itself, but has a callback to user.
+					else
+						T.harvest(src)
 			if(FARMBOT_WATER)
 				action = "water"
 				update_icons()
@@ -289,10 +292,10 @@
 	if(tray.closed_system || !tray.seed)
 		return 0
 
-	if(tray.dead && removes_dead || tray.harvest && collects_produce)
+	if(tray.dead || tray.harvest)
 		return FARMBOT_COLLECT
 
-	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent("water"))
+	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent("water") && tank.reagents.total_volume > 0)
 		return FARMBOT_WATER
 
 	else if(uproots_weeds && tray.weedlevel > 3)


### PR DESCRIPTION
AI code for farmbots is still glitchy. They'll continue to do activities while turned off and other nonsense, but it doesn't break the game horribly.

Also comes with a free sanity check.

I hate ss13 coders sometimes.

![image](https://user-images.githubusercontent.com/7409796/65213457-16bee880-da5b-11e9-94cb-375f94bf43bf.png)

Basically the problem was, in order (from previous fix):
The hydroponics tray was being called to attack the farmbot (which is impossible).
I reversed it so the farmbot would attack_hand the tray, which caused it to runtime and fail because not only does the farmbot have no client, but also because when a COLLECT fired, it would check to see if harvest() and remove_dead() fired, and would then re-fire COLLECT.
It will no longer recursively call itself and;
The harvest() and remove_dead() procs are now called directly instead of messing around with attack_hand.