### PR TITLE
Finally Fixes the Save-merge Bug

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -973,8 +973,20 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		var/obj/machinery/cryopod/CP = human_cryopods[input(usr,"Select a cryopod to use","Cryopod Choice") as null|anything in human_cryopods]
 		if(!CP)
 			return
+
+
+		var/mob/living/carbon/human/H = M
+		if(H.save_mob_to_prefs()) // saves character if round is canon.
+			spawn(20)
+			M << "<span class='notice'><b>Your character has now been saved.</b> All changes from this round will apply to your current character.</span>"
+		else
+			M << "<span class='notice'><b>As this is not a canon round, your character will not be saved this time.</b></span>"
+
+
 		M.ghostize()
 		CP.despawn_occupant(M)
+
+
 		return
 
 	else if(issilicon(M))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -379,9 +379,9 @@
 		var/mob/living/carbon/human/H = usr
 		if(H.save_mob_to_prefs()) // saves character if round is canon.
 			spawn(20)
-			M << "<span class='notice'><b>Your character has now been saved.</b> All changes from this round will apply to your current character.</span>"
+			H << "<span class='notice'><b>Your character has now been saved.</b> All changes from this round will apply to your current character.</span>"
 		else
-			M << "<span class='notice'><b>As this is not a canon round, your character will not be saved this time.</b></span>"
+			H << "<span class='notice'><b>As this is not a canon round, your character will not be saved this time.</b></span>"
 
 	usr << "<font color='blue'><B>Make sure to play a different character, and please roleplay correctly!</B></font>"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -345,6 +345,9 @@
 	if ((stat != 2 || !( ticker )))
 		usr << "<span class='notice'><B>You must be dead to use this!</B></span>"
 		return
+
+
+
 	if (ticker.mode && ticker.mode.deny_respawn) //BS12 EDIT
 		usr << "<span class='notice'>Respawn is disabled for this roundtype.</span>"
 		return
@@ -352,7 +355,7 @@
 		var/deathtime = world.time - src.timeofdeath
 		if(istype(src,/mob/observer/dead))
 			var/mob/observer/dead/G = src
-			if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+			if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted && !holder)
 				usr << "<font color='blue'><B>Upon using the antagHUD you forfeighted the ability to join the round.</B></font>"
 				return
 		var/deathtimeminutes = round(deathtime / 600)
@@ -366,13 +369,21 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
 
-		if ((deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
+		if (!holder && (deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
 			usr << "You must wait 5 minutes to respawn!"
 			return
 		else
 			usr << "You can respawn now, enjoy your new life!"
 
 	log_game("[usr.name]/[usr.key] used abandon mob.")
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.save_mob_to_prefs()) // saves character if round is canon.
+			spawn(20)
+			M << "<span class='notice'><b>Your character has now been saved.</b> All changes from this round will apply to your current character.</span>"
+		else
+			M << "<span class='notice'><b>As this is not a canon round, your character will not be saved this time.</b></span>"
 
 	usr << "<font color='blue'><B>Make sure to play a different character, and please roleplay correctly!</B></font>"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -346,8 +346,6 @@
 		usr << "<span class='notice'><B>You must be dead to use this!</B></span>"
 		return
 
-
-
 	if (ticker.mode && ticker.mode.deny_respawn) //BS12 EDIT
 		usr << "<span class='notice'>Respawn is disabled for this roundtype.</span>"
 		return
@@ -355,7 +353,7 @@
 		var/deathtime = world.time - src.timeofdeath
 		if(istype(src,/mob/observer/dead))
 			var/mob/observer/dead/G = src
-			if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted && !holder)
+			if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted && !client.holder)
 				usr << "<font color='blue'><B>Upon using the antagHUD you forfeighted the ability to join the round.</B></font>"
 				return
 		var/deathtimeminutes = round(deathtime / 600)
@@ -369,7 +367,7 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
 
-		if (!holder && (deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
+		if (!client.holder && (deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
 			usr << "You must wait 5 minutes to respawn!"
 			return
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -375,8 +375,8 @@
 
 	log_game("[usr.name]/[usr.key] used abandon mob.")
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
 		if(H.save_mob_to_prefs()) // saves character if round is canon.
 			spawn(20)
 			M << "<span class='notice'><b>Your character has now been saved.</b> All changes from this round will apply to your current character.</span>"

--- a/code/modules/persistence/persistent_characters.dm
+++ b/code/modules/persistence/persistent_characters.dm
@@ -7,7 +7,7 @@
 	if(!mind)
 		return 0
 
-	if(!unique_id == mind.prefs.unique_id)
+	if(!(unique_id == mind.prefs.unique_id))
 		return 0
 
 	//There's no way (that I know of) to edit the "real name" of a character unless

--- a/code/modules/persistence/persistent_characters.dm
+++ b/code/modules/persistence/persistent_characters.dm
@@ -7,6 +7,9 @@
 	if(!mind)
 		return 0
 
+	if(!unique_id)
+		return 0
+
 	if(!(unique_id == mind.prefs.unique_id))
 		return 0
 


### PR DESCRIPTION
No more overwritten slots.

This allows you to y'know, respawn and use new characters without the old one having issues.  If you ghost or respawn, your old character is saved (money and appearance) and you can safely move onto the next one without issues.

For characters that have previously merged into each other, however. Admins will need to make sure their unique IDs are different so avoid more merging, as it differentiates them using that.

Also, admins don't get held back by respawn timers any more, nor do they need to use "allow player to respawn verb" on themselves, kinda pointless. 