### PR TITLE
Stops people from stripping SSD players (Unless Antag/Police)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -235,6 +235,8 @@ var/list/gamemode_cache = list()
 	var/radiation_resistance_multiplier = 6.5
 	var/radiation_lower_limit = 0.35 //If the radiation level for a turf would be below this, ignore it.
 
+	var/ssd_protect = 0
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -699,6 +701,10 @@ var/list/gamemode_cache = list()
 				if("player_levels")
 					using_map.player_levels = text2numlist(value, ";")
 */
+
+				if("ssd_protect")
+					config.ssd_protect = text2num(value)
+
 				if("expected_round_length")
 					config.expected_round_length = MinutesToTicks(text2num(value))
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -70,6 +70,7 @@ proc/admin_notice(var/message, var/rights)
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
+		body += "\ <A HREF='?src=\ref[src];togglessdguard=\ref[M]'>Toggle SSD Guard</A> "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1015,6 +1015,28 @@
 		log_admin("[key_name(usr)] sent [key_name(M)] to the prison station.")
 		message_admins("<font color='blue'>[key_name_admin(usr)] sent [key_name_admin(M)] to the prison station.</font>", 1)
 
+
+	else if(href_list["togglessdguard"])
+		var/mob/M = locate(href_list["togglessdguard"])
+
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!M.client)
+			to_chat(usr, "<span class='warning'>[M] doesn't have an attached client.</span>")
+			return
+
+		var/onoff = "DISABLED"
+		if(M.client.bypass_ssd_guard)
+			M.client.bypass_ssd_guard = FALSE
+			onoff = "ENABLED"
+		else
+			M.client.bypass_ssd_guard = TRUE
+			to_chat(M, "<span class='warning'>You have been given temporary permission to interact with SSD players.</span>")
+
+		log_admin("[key_name(usr)] has [onoff] SSD Guard for [key_name(M)].")
+		message_admins("[key_name_admin(usr)] has [onoff] SSD Guard for [key_name(M)]")
+
 	else if(href_list["tdome1"])
 		if(!check_rights(R_FUN))	return
 

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -55,3 +55,5 @@
 
 	var/global/obj/screen/click_catcher/void
 
+	// Has the client been granted permission to mess with SSDs by an admin?
+	var/bypass_ssd_guard = FALSE

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -376,3 +376,14 @@ client/verb/character_setup()
 	if(prefs)
 		prefs.ShowChoices(usr)
 */
+
+/client/proc/can_harm_ssds()
+	if(!config.ssd_protect)
+		return 1
+	if(bypass_ssd_guard)
+		return 1
+	if(mob && mob.job in security_positions)
+		return 1
+	if(check_rights(R_ADMIN, 0, mob))
+		return 1
+	return 0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -309,9 +309,9 @@
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ("brain") || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span><br>"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. The classical symptoms of SSD disorder. It doesn't look like [T.he] [T.is] waking up anytime soon.</span><br>"
 		else if(!client)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span><br>"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. The classical symptoms of SSD disorder.</span><br>"
 
 	var/list/wound_flavor_text = list()
 	var/list/is_bleeding = list()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -164,6 +164,9 @@
 		plane_holder.set_vis(vis,FALSE)
 		vis_enabled -= vis
 
+/proc/isLivingSSD(mob/living/M)
+	return istype(M) && !M.client || !M.key && M.stat != DEAD
+
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -7,6 +7,12 @@
 		user << browse(null, text("window=mob[src.name]"))
 		return
 
+	if(isLivingSSD(src))
+		if(user.client && !user.client.can_harm_ssds() && !isAntag(user))
+			to_chat(user, "<span class='warning'>AdminHelp (F1) to get permission before stripping players who are suffering from Space Sleep Disorder / disconnected from the game. Read the server rules for more details.</span>")
+			return
+
+
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip))
 
 	switch(slot_to_strip)
@@ -38,6 +44,8 @@
 			var/obj/item/clothing/accessory/A = suit.accessories[1]
 			if(!istype(A))
 				return
+
+
 			visible_message("<span class='danger'>\The [usr] is trying to remove \the [src]'s [A.name]!</span>")
 
 			if(!do_after(user,HUMAN_STRIP_DELAY,src))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -673,3 +673,11 @@ var/global/image/backplane
 			if(!mob.mind)
 				return
 			return mob.mind.initial_email_login["login"]
+
+/proc/isAntag(A)
+	if(istype(A, /mob/living/carbon))
+		var/mob/living/carbon/C = A
+		if(C.mind && C.mind.special_role)
+			return 1
+	return 0
+


### PR DESCRIPTION
Port from Paradise. This does what it says on the tin. Admins will have a button to toggle this setting off/on, and it's also a configuration option that can be disabled in general if needed.

![image](https://user-images.githubusercontent.com/12565163/67506702-77a69580-f685-11e9-9b67-a0be15533eb0.png)

Antagonists and police can strip SSDs, within reason, but those roles are jobbannable if they are abused so we'll see how it goes.

Additionally, just made it more clearer (with a message) who is suffering from SSD vs who is simply sleeping.