### PR TITLE
Makes weapons crates robust

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -340,6 +340,7 @@
 	icon_state = "weaponcrate"
 	icon_opened = "weaponcrateopen"
 	icon_closed = "weaponcrate"
+	health = 90000
 
 /obj/structure/closet/crate/secure/phoron
 	name = "phoron crate"


### PR DESCRIPTION
After reports that weapons crates being insecure was funding a gun blackmarket, nanotrasen put extra reinforcements on security requirement legislation on the crate making businesses when it comes to weapons crates.

So lolgun cargo is going to be a lot harder. 