### PR TITLE
Persistent Prisoner Statuses

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -153,3 +153,9 @@
 		uniform = /obj/item/clothing/under/suit_jacket/checkered/skirt
 	else
 		uniform = /obj/item/clothing/under/suit_jacket/checkered
+
+/decl/hierarchy/outfit/job/assistant/prisoner
+	name = OUTFIT_JOB_NAME("Prisoner")
+	id_pda_assignment = "Prisoner"
+	uniform = /obj/item/clothing/under/color/orange
+	shoes = /obj/item/clothing/shoes/orange

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,6 +77,12 @@ datum/preferences
 	var/religion = "None"               //Religious association.
 	var/antag_faction = "None"			//Antag associated faction.
 	var/antag_vis = "Shared"			//How visible antag association is to others.
+	
+	// Antag and Prison stuff
+	
+	var/criminal_status = "None"
+	var/prison_date				//date someone was put in prison
+	var/prison_release_date			//date someone is due to be released from prison
 
 		//Mob preview
 	var/icon/preview_icon = null
@@ -159,6 +165,7 @@ datum/preferences
 	var/loadprefcooldown
 	var/savecharcooldown
 	var/loadcharcooldown
+
 
 /datum/preferences/New(client/C)
 	player_setup = new(src)


### PR DESCRIPTION
Graytide ain't gonna like this. Only applies to individual characters.

- [x] Adds criminal status and prison date/release vars to preferences.
- [ ] Reworking with the new records system so all "arrests" and "warrants" are associated with a law.
- [x] Reworking laws so permanent sentences/capital crimes are in days instead of "forever" unless they're death penalty.
- [ ] Make end of round code check for all people who have their criminal status set to "arrest" or "incarcerated" with a crime while in prison or shuttle prison area to be in jail the next round. 
- [ ] Someone who has been successfully arrested previous round can only spawn with prisoner role in prisoner clothing.
- [ ] If someone with the "in prison" status is not in jail or the jail shuttle by the end of the round, they are automatically set to arrest and can only play "civilian" role.