### PR TITLE
Fixes all emotes being invalid

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -155,13 +155,6 @@ proc/get_radio_key_from_channel(var/channel)
 	//Parse the mode
 	var/message_mode = parse_message_mode(message, "headset")
 
-	//If there's no punctuation, add punctuation.
-	var/p_ending = copytext(message, length(message))
-	var/p_message = "[message]."
-	if(!(p_ending in list(".","?","!")))
-		if(message)
-			message = p_message
-
 	//Allow them use to markup, if used.
 	message = process_chat_markup(message, list("~", "_"))
 
@@ -169,6 +162,13 @@ proc/get_radio_key_from_channel(var/channel)
 	switch(copytext(message,1,2))
 		if("*") return emote(copytext(message,2))
 		if("^") return custom_emote(1, copytext(message,2))
+
+	//If there's no punctuation, add punctuation.
+	var/p_ending = copytext(message, length(message))
+	var/p_message = "[message]."
+	if(!(p_ending in list(".","?","!")))
+		if(message)
+			message = p_message
 
 	//Parse the radio code and consume it
 	if (message_mode)


### PR DESCRIPTION
Recent change cause auto-punctuation to put a dot at the end of the message before it was processed by emote catching statement, leading to all emotes being invalid and therefore not work at all when you used * in the say box.