### PR TITLE
Poxball Rebalance

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -221,8 +221,8 @@
 	name = "charged poxball"
 	icon_state = "poxball"
 	fire_sound = 'sound/weapons/poxball_launched.ogg'
-	damage = 5
-	agony = 10
+	damage = 10
+	agony = 35
 	pass_flags = PASSTABLE
 	light_color = "#619EFF"
 	light_range = 2


### PR DESCRIPTION
**Poxball Rebalance**

**Fixes**

- Poxball agony damage has been buffed. It now takes 6-8 balls to knock out a fully armored player. In addition, poxballs now do more burn damage. 

Poxball is a combat sport and outside of the arena Poxball Launchers are a very dangerous weapon in the wrong hands. 