### PR TITLE
Business Management Utility bugfix

### DIFF
--- a/code/modules/government/businesses.dm
+++ b/code/modules/government/businesses.dm
@@ -30,7 +30,6 @@ var/global/list/businesses = list()
 	var/list/applicants = list()
 
 /proc/get_all_businesses(mob/user) //Displays all businesses in a table.
-	user.client.debug_variables(businesses)
 	var/dat = list()
 	dat += "<center>"
 	if(!businesses.len)


### PR DESCRIPTION
Removes debug_variables when clicking "View Existing Businesses." Players will no longer see "You have to be an administrator to use this" and admins will no longer get the view variables popup.