### PR TITLE
Gov Emails and Fixes Email Dupe Account Bug

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -52,14 +52,14 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 // Subsystem init_order, from highest priority to lowest priority
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.
-#define INIT_ORDER_EARLY        19
-#define INIT_ORDER_CHEMISTRY	18
+#define INIT_ORDER_EARLY     		19
+#define INIT_ORDER_CHEMISTRY		18
 #define INIT_ORDER_MAPPING		17
 #define INIT_ORDER_DECALS		16
-#define INIT_ORDER_ATOMS		15
+#define INIT_ORDER_ATOMS			15
 #define INIT_ORDER_MACHINES		10
 #define INIT_ORDER_SHUTTLES		3
-#define INIT_ORDER_TIMER		1
+#define INIT_ORDER_TIMER			1
 #define INIT_ORDER_DEFAULT		0
 #define INIT_ORDER_LIGHTING		0
 #define INIT_ORDER_AIR			-1
@@ -73,7 +73,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_PAYROLL		-24
 #define INIT_ORDER_ELECTIONS		-25
 #define INIT_ORDER_LAW			-26
-
+#define INIT_ORDER_EMAILS		-27
 
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)

--- a/code/controllers/subsystems/elections.dm
+++ b/code/controllers/subsystems/elections.dm
@@ -217,7 +217,7 @@ SUBSYSTEM_DEF(elections)
 	postelection_news_article()
 
 	// change the prez email so the old president can't get back into the email...
-
+	SSemails.change_persistent_email_password(using_map.president_email, GenerateKey())
 
 	postelection_email()
 
@@ -262,11 +262,11 @@ SUBSYSTEM_DEF(elections)
 
 
 	eml_cnt += "Congratulations on winning the presidential race this month, you are now President of the colony. Your presidency shall last a month, \
-	so make the most of it.\[editorbr\] Being a President is an arduous duty with many responsibilities - it involves keeping a colony in line \
+	so make the most of it.\[br\] Being a President is an arduous duty with many responsibilities - it involves keeping a colony in line \
 	and retaining the appeal of the citizens, during your presidency you must also adhere to the company's guidelines."
 
 
-	eml_cnt += "You must keep the following in mind at all times:\[editorbr\]"
+	eml_cnt += "You must keep the following in mind at all times:\[br\]"
 
 	eml_cnt += "\[list\] \
 	\[*\] Image: Do not debase or slander the corporation in a way that would make it lose credibility in the eyes of our citizens, \
@@ -279,12 +279,12 @@ SUBSYSTEM_DEF(elections)
 
 	eml_cnt += "\[editorbr\]As president, you are able to modify various aspects of the colony such as taxes, laws, contraband, et cetera, \
 	and can do this through the presidential portal. You may also assign a vice president and some ministers to help you get work done in the short \
-	time that you have.\[editorbr\]"
+	time that you have. \[editorbr\]"
 
-	eml_cnt += "Your work email is [prez_email.login] and the password is [prez_email.login] - do not share these details. If your account does \
-	become compromised, you may request a password change from the Nanotrasen IT department sector, but this will come at a cost of 5,500 credits.\[editorbr\]"
+	eml_cnt += "\[br\]Your work email is \[b]\[prez_email.login]\[\b]\ and the password is \[b]\[prez_email.password]\[\b]\ - do not share these details. If your account does \
+	become compromised, you may request a password change from the Nanotrasen IT department sector, but this will come at a cost of 5,500 credits. \[editorbr\]"
 
-	eml_cnt += "As you manage the colony it is important to be mindful of your own image, citizens can vote against you - if thirty no confidence \
+	eml_cnt += "\[br\]As you manage the colony it is important to be mindful of your own image, citizens can vote against you - if thirty no confidence \
 	votes are reached you will be removed from your post, please beware.\[editorbr\] We hope you have a fruitful term, and wish you all the best. \[editorbr\] \
 	Best Regards, \[editorbr\]Nanotrasen Headquarters"
 

--- a/code/controllers/subsystems/elections.dm
+++ b/code/controllers/subsystems/elections.dm
@@ -74,7 +74,7 @@ SUBSYSTEM_DEF(elections)
 /datum/controller/subsystem/elections/proc/get_next_election_month()
 	var/info
 
-	if(get_game_day() > 28)
+	if(get_game_day() > 27)
 		if(get_game_month() == 12) // If it's december, the next year will be January.
 			info = 1
 		else
@@ -108,12 +108,6 @@ SUBSYSTEM_DEF(elections)
 	CheckNoConfidence()
 	SetNewPresident()
 
-
-/datum/controller/subsystem/elections/proc/SetupEmails()
-	//makes sure an email exists for these emails.
-	for(var/E in government_emails)
-		if(!check_persistent_email(E))
-			new_persistent_email(E)
 
 /datum/controller/subsystem/elections/proc/CheckNoConfidence()
 	if(!current_president) // This shouldn't happen except for when you start the same anew.
@@ -222,6 +216,11 @@ SUBSYSTEM_DEF(elections)
 
 	postelection_news_article()
 
+	// change the prez email so the old president can't get back into the email...
+
+
+	postelection_email()
+
 	return winning_vote
 
 /datum/controller/subsystem/elections/proc/clear_president()
@@ -243,6 +242,64 @@ SUBSYSTEM_DEF(elections)
 	total_votes = votes
 
 	return votes
+
+
+/datum/controller/subsystem/elections/proc/postelection_email()
+	if(!using_map.president_email) return
+	if(!current_president) return
+	if(!current_president.ckey) return // In case it's NT officials
+
+	var/datum/computer_file/data/email_account/prez_email = get_email(using_map.president_email)
+
+	if(!prez_email) return
+
+	var/datum/computer_file/data/email_message/message = new/datum/computer_file/data/email_message()
+
+	var/eml_cnt
+
+
+	eml_cnt = "Dear [current_president], \[editorbr\]"
+
+
+	eml_cnt += "Congratulations on winning the presidential race this month, you are now President of the colony. Your presidency shall last a month, \
+	so make the most of it.\[editorbr\] Being a President is an arduous duty with many responsibilities - it involves keeping a colony in line \
+	and retaining the appeal of the citizens, during your presidency you must also adhere to the company's guidelines."
+
+
+	eml_cnt += "You must keep the following in mind at all times:\[editorbr\]"
+
+	eml_cnt += "\[list\] \
+	\[*\] Image: Do not debase or slander the corporation in a way that would make it lose credibility in the eyes of our citizens, \
+	or to Sol. Our main institution is in Sol, if we lose face on our colony, we lose our most secure footing. Retain as much PR as possible or face removal.\
+	\[br\]\[*\] Profit: Do not cause the colony to fall into debt, or allow it to remain in debt. You must sure profits are kept to a healthy level so company \
+	growth can continue. You have freedom in what methods you utilize to do this, as long as they are within the charter. \[br\] \
+	\[*\] Power: Nanotrasen owns this colony, a president has access to the steering wheel but not the vehicle; ensure that it is kept under control. \
+	If agents on the colony try to gain power you must utilize the resources given to you to stop it. Do not form militias to usurp power from Nanotrasen \
+	or delibrately cause chaos on the colony. Remember that Nanotrasen has a blue space artiltery - do you? \[/list\]"
+
+	eml_cnt += "\[editorbr\]As president, you are able to modify various aspects of the colony such as taxes, laws, contraband, et cetera, \
+	and can do this through the presidential portal. You may also assign a vice president and some ministers to help you get work done in the short \
+	time that you have.\[editorbr\]"
+
+	eml_cnt += "Your work email is [prez_email.login] and the password is [prez_email.login] - do not share these details. If your account does \
+	become compromised, you may request a password change from the Nanotrasen IT department sector, but this will come at a cost of 5,500 credits.\[editorbr\]"
+
+	eml_cnt += "As you manage the colony it is important to be mindful of your own image, citizens can vote against you - if thirty no confidence \
+	votes are reached you will be removed from your post, please beware.\[editorbr\] We hope you have a fruitful term, and wish you all the best. \[editorbr\] \
+	Best Regards, \[editorbr\]Nanotrasen Headquarters"
+
+	eml_cnt = jointext(eml_cnt,null)
+
+	message.stored_data = eml_cnt
+	message.title = "Congratulations on Presidency: [current_president.name]"
+	message.source = "noreply@nanotrasen.gov.nt"
+	message.timestamp = stationtime2text()
+
+	prez_email.send_mail(prez_email.login, message)
+
+	prez_email.save_email()
+
+	return 1
 
 
 /datum/controller/subsystem/elections/proc/postelection_news_article()
@@ -279,7 +336,7 @@ SUBSYSTEM_DEF(elections)
 	message = "<b>Castor Headquarters: [full_game_time()]</b> - Electoral Assistants of [using_map.boss_name] have counted the final votes and \
 	presented the electoral results to all, there were [last_election_votes] total. \
 	People from several continents on Pollux watched as the name was pulled from the traditional ballot hat. \
-	<p>Millions of people gathered in-person to watch the event, others stayed home to observe their televisions and communicator screens \
+	<br><br>Millions of people gathered in-person to watch the event, others stayed home to observe their televisions and communicator screens \
 	as they watch Pollux's moon through their screens. Many [pick(prospectors)] [pick(getformernames())] would win based on the monthly election president website \
 	electionpredictions.nt."
 

--- a/code/controllers/subsystems/emails.dm
+++ b/code/controllers/subsystems/emails.dm
@@ -1,0 +1,243 @@
+SUBSYSTEM_DEF(emails)
+	name = "Emails"
+	init_order = INIT_ORDER_EMAILS
+	flags = SS_NO_FIRE
+
+/datum/controller/subsystem/emails/Initialize(timeofday)
+	SetupGovEmails()
+
+	..()
+
+
+/datum/controller/subsystem/emails/proc/GetGovEmails()
+	var/list/gov_emails = list()
+
+	gov_emails += using_map.president_email
+	gov_emails += using_map.vice_email
+	gov_emails += using_map.boss_email
+	gov_emails += using_map.director_email
+
+	gov_emails += using_map.minister_defense_email
+	gov_emails += using_map.minister_health_email
+	gov_emails += using_map.minister_innovation_email
+	gov_emails += using_map.minister_justice_email
+	gov_emails += using_map.minister_information_email
+
+	return gov_emails
+
+
+/datum/controller/subsystem/emails/proc/SetupGovEmails()
+	//makes sure an email exists for these emails.
+	for(var/E in GetGovEmails())
+		if(!E)
+			continue
+
+		var/datum/computer_file/data/email_account/email
+
+		if(!check_persistent_email(E))
+			new_persistent_email(E)
+
+		email = manifest_persistent_email(E)
+		email.max_messages = 1000
+
+	return 1
+
+
+/datum/controller/subsystem/emails/proc/save_all_emails()
+	if(!config.canonicity)
+		return 0
+
+	for(var/datum/computer_file/data/email_account/account in ntnet_global.email_accounts)
+		account.save_email()
+
+	return 1
+
+
+/datum/controller/subsystem/emails/proc/manifest_persistent_email(address)
+	var/datum/computer_file/data/email_account/account = new/datum/computer_file/data/email_account()
+	account.login = address
+
+	if(!account.get_persistent_data())
+		return 0
+
+	return account
+
+/datum/controller/subsystem/emails/proc/new_persistent_email(var/address, var/password)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	var/pass
+
+	if(!password)
+		pass = GenerateKey()
+	else
+		pass = password
+
+	S["login"] << address
+	S["inbox"] << list()
+	S["outbox"] << list()
+	S["spam"] << list()
+	S["deleted"] << list()
+	S["password"] << pass
+	S["max_messages"] << 50
+
+	return full_path
+
+
+
+/datum/controller/subsystem/emails/proc/send_to_persistent_email(var/address, var/datum/computer_file/data/email_message/message)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(!fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	if(!message)
+		return 0
+
+	var/list/inbox = list()
+	var/list/spam = list()
+	var/list/deleted = list()
+	var/list/outbox = list()
+
+	var/max_messages
+
+	S["inbox"]		>>	inbox
+	S["outbox"]		>>	outbox
+	S["spam"]			>>	spam
+	S["deleted"]		>>	deleted
+
+	S["max_messages"]	>>	max_messages
+
+	var/list/all_messages = 	(inbox | spam | deleted | outbox)
+
+	if(!isemptylist(all_messages))
+		if((all_messages.len - 1) > max_messages)
+			return 0
+
+	if(message.spam)
+		if(prob(98))
+			spam += message
+		else
+			inbox += message
+	else
+		if(prob(1))
+			spam += message
+		else
+			inbox += message
+
+	S["inbox"] << inbox
+	S["spam"] << spam
+
+	return 1
+
+
+
+/datum/controller/subsystem/emails/proc/check_persistent_email(var/address)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(fexists(full_path))	return full_path
+
+	return 0
+
+/datum/controller/subsystem/emails/proc/generate_email(var/name)
+	var/new_email = "[replacetext(lowertext(name), " ", ".")][rand(1,500)]@[pick(using_map.usable_email_tlds)]"
+
+	return new_email
+
+
+/datum/controller/subsystem/emails/proc/get_persistent_email_suspended(var/address)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(!fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	var/suspended
+
+	S["suspended"] >> suspended
+
+	return suspended
+
+
+
+/datum/controller/subsystem/emails/proc/get_persistent_email_password(var/address)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(!fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	var/password
+
+	S["password"] >> password
+
+	return password
+
+
+/datum/controller/subsystem/emails/proc/change_persistent_email_address(var/address, var/new_address)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(!fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	var/adr
+
+	S["login"] >> adr
+
+	adr = new_address
+
+	S["login"] << adr
+
+	return adr
+
+/datum/controller/subsystem/emails/proc/change_persistent_email_password(var/address, var/new_pass)
+	var/full_path = "data/persistent/emails/[address].sav"
+	if(!full_path)			return 0
+	if(!fexists(full_path)) return 0
+
+	var/savefile/S = new /savefile(full_path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	if(!address)
+		return 0
+
+	var/pass
+
+	S["password"] >> pass
+
+	pass = new_pass
+
+	S["password"] << pass
+
+	return pass

--- a/code/controllers/subsystems/emails.dm
+++ b/code/controllers/subsystems/emails.dm
@@ -15,7 +15,11 @@ SUBSYSTEM_DEF(emails)
 	gov_emails += using_map.president_email
 	gov_emails += using_map.vice_email
 	gov_emails += using_map.boss_email
+	gov_emails += using_map.rep_email
 	gov_emails += using_map.director_email
+	gov_emails += using_map.investigation_email
+
+	gov_emails += using_map.council_email
 
 	gov_emails += using_map.minister_defense_email
 	gov_emails += using_map.minister_health_email

--- a/code/controllers/verbs.dm
+++ b/code/controllers/verbs.dm
@@ -63,7 +63,7 @@
 		usr.client.debug_variables(antag)
 		message_admins("Admin [key_name_admin(usr)] is debugging the [antag.role_text] template.")
 
-/client/proc/debug_controller(controller in list("Master","Ticker","Ticker Process","Air","Jobs","Sun","Radio","Supply","Shuttles","Emergency Shuttle","Configuration","pAI", "Cameras", "Transfer Controller", "Gas Data","Event","Plants","Alarm","Nano","Chemistry","Vote","Xenobio","Planets"))
+/client/proc/debug_controller(controller in list("Master","Ticker","Ticker Process","Air","Jobs","Sun","Emails","Radio","Supply","Shuttles","Emergency Shuttle","Configuration","pAI", "Cameras", "Transfer Controller", "Gas Data","Event","Plants","Alarm","Nano","Chemistry","Vote","Xenobio","Planets"))
 	set category = "Debug"
 	set name = "Debug Controller"
 	set desc = "Debug the various periodic loop controllers for the game (be careful!)"
@@ -133,5 +133,8 @@
 		if("Planets")
 			debug_variables(SSplanets)
 			feedback_add_details("admin_verb", "DPlanets")
+		if("Emails")
+			debug_variables(SSemails)
+			feedback_add_details("admin_verb", "DEmails")
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
 	return

--- a/code/game/jobs/job/council.dm
+++ b/code/game/jobs/job/council.dm
@@ -23,6 +23,12 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	ideal_character_age = 50 // Old geezer captains ftw // Get your MILF/DILF fetish out of here //OwO What's this? // what the fuck - myo
 
 	outfit_type = /decl/hierarchy/outfit/job/heads/captain
+
+
+/datum/job/captain/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
+
+
 //	alt_titles = list("Site Manager", "Overseer")
 
 /*
@@ -70,6 +76,10 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
+
+/datum/job/hop/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
+
 /datum/job/judge
 	title = "Judge"
 	flag = JUDGE
@@ -92,3 +102,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	alt_titles = list("Magistrate")
 
 	outfit_type = /decl/hierarchy/outfit/job/heads/judge
+
+/datum/job/judge/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email

--- a/code/game/jobs/job/emergency.dm
+++ b/code/game/jobs/job/emergency.dm
@@ -30,6 +30,10 @@
 	minimal_player_age = 7
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
+
+
+/datum/job/chief_engineer/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
 /*
 /datum/job/engineer
 	title = "Firefighter"

--- a/code/game/jobs/job/hospital.dm
+++ b/code/game/jobs/job/hospital.dm
@@ -28,6 +28,9 @@
 	alt_titles = list(
 		"Chief of Medicine", "Medical Director")
 
+/datum/job/cmo/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
+
 /datum/job/doctor
 	title = "Doctor"
 	email_domain = "med.gov.nt"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -30,6 +30,10 @@
 
 	var/hard_whitelisted = 0 // jobs that are hard whitelisted need players to be added to hardjobwhitelist.txt with the format [ckey] - [job] in order to work.
 
+/datum/job/proc/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return
+
+
 /datum/job/proc/equip(var/mob/living/carbon/human/H, var/alt_title)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title)
 	if(!outfit)

--- a/code/game/jobs/job/nanotrasen.dm
+++ b/code/game/jobs/job/nanotrasen.dm
@@ -25,6 +25,9 @@
 
 	hard_whitelisted = 1
 
+/datum/job/nanotrasen/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.rep_email
+
 /datum/job/nanotrasen/New()
 	..()
 	department = "[station_name()] Funds"
@@ -43,7 +46,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/nanotrasen/captain
 	idtype = /obj/item/weapon/card/id/nanotrasen/ceo
 	minimum_character_age = 30
-	
+
 /datum/job/nanotrasen/cbia
 	title = "PDSI Agent"
 	flag = CBIA
@@ -69,6 +72,9 @@
 	ideal_character_age = 40
 	req_admin_notify = 1
 
+/datum/job/nanotrasen/cbia/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.investigation_email
+
 /datum/job/nanotrasen/president
 	title = "President"
 	flag = PRESIDENT
@@ -93,3 +99,5 @@
 	outfit_type = /decl/hierarchy/outfit/job/heads/president
 
 
+/datum/job/nanotrasen/president/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.president_email

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -25,6 +25,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 	alt_titles = list("Head of Police", "Police Commander", "Police Commissioner", "Police Chief")
 
+/datum/job/hos/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
+
 /datum/job/warden
 	title = "Prison Warden"
 	email_domain = "secure.plux.gov.nt"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -29,6 +29,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	alt_titles = list("Research Supervisor")
 
+/datum/job/rd/get_job_email()	// whatever this is set to will be the job's communal email. should be persistent.
+	return using_map.council_email
+
 /datum/job/scientist
 	title = "Scientist"
 	email_domain = "sciworks.nt"

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -524,6 +524,8 @@ var/global/datum/controller/occupations/job_master
 		var/complete_login = H.client.prefs.email
 		var/datum/computer_file/data/email_account/EA
 
+		var/datum/computer_file/data/email_account/job_email = get_email(job.get_job_email())
+
 		// If someone already joined and email is already in-game.
 		for(var/datum/computer_file/data/email_account/account in ntnet_global.email_accounts)
 			if(account.login == H.client.prefs.email)
@@ -531,22 +533,24 @@ var/global/datum/controller/occupations/job_master
 				EA = account
 				break
 
-		if(H.client.prefs.email && !check_persistent_email(H.client.prefs.email))
-			EA = manifest_persistent_email(H.client.prefs.email) // so this saves without having to make dupes over and over.
+		if(H.client.prefs.email && !SSemails.check_persistent_email(H.client.prefs.email))
+			SSemails.new_persistent_email(H.client.prefs.email) // so this saves without having to make dupes over and over.
+			EA = SSemails.manifest_persistent_email(H.client.prefs.email)
 
 		if(!EA)
 			EA = new/datum/computer_file/data/email_account()
-			EA.password = get_persistent_email_password(complete_login)
+			EA.password = SSemails.get_persistent_email_password(complete_login)
 			EA.login = complete_login
-			
+
 
 		H.mind.initial_email_login = list("login" = "[EA.login]", "password" = "[EA.password]")
 		H.mind.initial_email = EA
 
-
-		to_chat(H, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
+		if(job_email)
+			to_chat(H, "Your workplace's email address is <b>[job_email.login]</b> and the password is <b>[job_email.password]</b>.")
+		to_chat(H, "Your personal email address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
 		H.mind.store_memory("Your email account address is [EA.login] and the password is [EA.password].")
-
+		H.mind.store_memory("Your workplace account address is [job_email.login] and the password is [job_email.password].")
 
 		// END EMAIL GENERATION
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -532,13 +532,13 @@ var/global/datum/controller/occupations/job_master
 				break
 
 		if(H.client.prefs.email && !check_persistent_email(H.client.prefs.email))
-			new_persistent_email(H.client.prefs.email) // so this saves without having to make dupes over and over.
+			EA = manifest_persistent_email(H.client.prefs.email) // so this saves without having to make dupes over and over.
 
 		if(!EA)
 			EA = new/datum/computer_file/data/email_account()
 			EA.password = get_persistent_email_password(complete_login)
 			EA.login = complete_login
-			EA.get_persistent_data()
+			
 
 		H.mind.initial_email_login = list("login" = "[EA.login]", "password" = "[EA.password]")
 		H.mind.initial_email = EA

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -81,7 +81,7 @@
 
 	id_card.age = age
 	if(mind)
-		id_card.associated_email_login = list("login" = "[mind.prefs.email]", "password" = "[get_persistent_email_password(mind.prefs.email)]")
+		id_card.associated_email_login = list("login" = "[mind.prefs.email]", "password" = "[SSemails.get_persistent_email_password(mind.prefs.email)]")
 		id_card.unique_ID = mind.prefs.unique_id
 
 	return 1

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -86,9 +86,9 @@ datum/preferences/proc/set_biological_gender(var/gender)
 		pref.unique_id			= md5("[pref.client_ckey][rand(30,50)]")
 
 	if(!pref.email)
-		var/new_email = generate_email(pref.real_name)
+		var/new_email = SSemails.generate_email(pref.real_name)
 
-		if(!ntnet_global.does_email_exist(new_email) || !check_persistent_email(new_email))
+		if(!ntnet_global.does_email_exist(new_email) || !SSemails.check_persistent_email(new_email))
 			pref.email = new_email
 
 
@@ -152,7 +152,7 @@ F
 	if(!pref.existing_character)
 		. += "Email: <a href='?src=\ref[src];email_domain=1'>[pref.email]</a><br><br>"
 	else
-		. += "Login: [pref.email]<br>Password: [get_persistent_email_password(pref.email)] <br><br>"
+		. += "Login: [pref.email]<br>Password: [SSemails.get_persistent_email_password(pref.email)] <br><br>"
 
 	if(pref.existing_character)
 		. += "<b>Unique Character ID:</b> [pref.unique_id]<br>"
@@ -237,17 +237,17 @@ F
 
 		var/full_email = "[prefix]@[domain]"
 
-		if(full_email && check_persistent_email(full_email))
+		if(full_email && SSemails.check_persistent_email(full_email))
 			alert(user, "This email already exists, please choose another.")
 			return
 
-		if(full_email && !check_persistent_email(pref.email))
-			new_persistent_email(full_email)
+		if(full_email && !SSemails.check_persistent_email(pref.email))
+			SSemails.new_persistent_email(full_email)
 
 
 		fcopy("data/persistent/emails/[pref.email].sav","data/persistent/emails/[full_email].sav")
 		fdel("data/persistent/emails/[pref.email].sav")
-		change_persistent_email_address(pref.email, full_email)
+		SSemails.change_persistent_email_address(pref.email, full_email)
 
 		pref.email = "[prefix]@[domain]"
 

--- a/code/modules/modular_computers/NTNet/emails/email_account.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_account.dm
@@ -69,7 +69,7 @@
 
 	if(config.canonicity)
 		// If not, send to a persistent email address out of game. (If it's a canon round.)
-		if(send_to_persistent_email(recipient_address, message))
+		if(SSemails.send_to_persistent_email(recipient_address, message))
 			outbox.Add(message)
 			ntnet_global.add_log_with_ids_check("EMAIL LOG: [login] -> [recipient_address] title: [message.title].")
 			return 1

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -91,20 +91,6 @@
 				error = "Invalid Password"
 				return 0
 
-		else
-			// checking our persistent emails for this email so we can login offline. if it's successful and the email
-			// isn't suspended, it'll make a copy and it will exist in-game (late joining owners of this email will be
-			// able to use it as normal too.
-			if(check_persistent_email(stored_login))
-				if(get_persistent_email_suspended(stored_login))
-					error = "This account has been suspended. Please contact the system administrator for assistance."
-					return 0
-				else
-					if((get_persistent_email_password(stored_login) == stored_password))
-						current_account = manifest_persistent_email(stored_login)
-						return 1
-
-
 	if(current_account)
 		return 1
 

--- a/code/modules/persistence/persistent_emails.dm
+++ b/code/modules/persistence/persistent_emails.dm
@@ -1,11 +1,4 @@
-/proc/save_all_emails()
-	if(!config.canonicity)
-		return 0
 
-	for(var/datum/computer_file/data/email_account/account in ntnet_global.email_accounts)
-		account.save_email()
-
-	return 1
 
 /datum/computer_file/data/email_account/proc/save_email()
 	var/full_path = "data/persistent/emails/[login].sav"
@@ -27,15 +20,6 @@
 	S["max_messages"] 	<<		max_messages
 
 	return 1
-
-/proc/manifest_persistent_email(address)
-	var/datum/computer_file/data/email_account/account = new/datum/computer_file/data/email_account()
-	account.login = address
-
-	if(!account.get_persistent_data())
-		return 0
-
-	return account
 
 
 
@@ -59,156 +43,9 @@
 	return 1
 
 
-/proc/new_persistent_email(var/address, var/password)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(fexists(full_path)) return 0
-
-	var/savefile/S = new /savefile(full_path)
-	if(!S)					return 0
-	S.cd = "/"
-
-	if(!address)
-		return 0
-
-	var/pass
-
-	if(!password)
-		pass = GenerateKey()
-	else
-		pass = password
-
-	S["login"] << address
-	S["inbox"] << list()
-	S["outbox"] << list()
-	S["spam"] << list()
-	S["deleted"] << list()
-	S["password"] << pass
-	S["max_messages"] << 50
-
-	return full_path
 
 
 
-/proc/send_to_persistent_email(var/address, var/datum/computer_file/data/email_message/message)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(!fexists(full_path)) return 0
-
-	var/savefile/S = new /savefile(full_path)
-	if(!S)					return 0
-	S.cd = "/"
-
-	if(!address)
-		return 0
-
-	if(!message)
-		return 0
-
-	var/list/inbox = list()
-	var/list/spam = list()
-	var/list/deleted = list()
-	var/list/outbox = list()
-
-	var/max_messages
-
-	S["inbox"]		>>	inbox
-	S["outbox"]		>>	outbox
-	S["spam"]			>>	spam
-	S["deleted"]		>>	deleted
-
-	S["max_messages"]	>>	max_messages
-
-	var/list/all_messages = 	(inbox | spam | deleted | outbox)
-
-	if(!isemptylist(all_messages))
-		if((all_messages.len - 1) > max_messages)
-			return 0
-
-	if(message.spam)
-		if(prob(98))
-			spam += message
-		else
-			inbox += message
-	else
-		if(prob(1))
-			spam += message
-		else
-			inbox += message
-
-	S["inbox"] << inbox
-	S["spam"] << spam
-
-	return 1
-
-/proc/check_persistent_email(var/address)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(fexists(full_path))	return full_path
-
-	return 0
-
-/proc/generate_email(var/name)
-	var/new_email = "[replacetext(lowertext(name), " ", ".")][rand(1,500)]@[pick(using_map.usable_email_tlds)]"
-
-	return new_email
 
 
-/proc/get_persistent_email_suspended(var/address)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(!fexists(full_path)) return 0
 
-	var/savefile/S = new /savefile(full_path)
-	if(!S)					return 0
-	S.cd = "/"
-
-	if(!address)
-		return 0
-
-	var/suspended
-
-	S["suspended"] >> suspended
-
-	return suspended
-
-
-/proc/get_persistent_email_password(var/address)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(!fexists(full_path)) return 0
-
-	var/savefile/S = new /savefile(full_path)
-	if(!S)					return 0
-	S.cd = "/"
-
-	if(!address)
-		return 0
-
-	var/password
-
-	S["password"] >> password
-
-	return password
-
-/proc/change_persistent_email_address(var/address, var/new_address)
-	var/full_path = "data/persistent/emails/[address].sav"
-	if(!full_path)			return 0
-	if(!fexists(full_path)) return 0
-
-	var/savefile/S = new /savefile(full_path)
-	if(!S)					return 0
-	S.cd = "/"
-
-	if(!address)
-		return 0
-
-	var/adr
-
-	S["login"] >> adr
-
-	adr = new_address
-
-	S["login"] << adr
-
-	return adr

--- a/code/modules/persistence/persistent_world.dm
+++ b/code/modules/persistence/persistent_world.dm
@@ -10,7 +10,7 @@
 	news_data.save_main_news()
 
 	//save emails
-	save_all_emails()
+	SSemails.save_all_emails()
 
 	//saves all characters
 	for (var/mob/living/carbon/human/H in mob_list) //only humans, we don't really save AIs or robots.

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -95,6 +95,21 @@ var/list/all_maps = list()
 
 	var/list/usable_email_tlds = list("freemail.net")
 
+	var/president_email = "president@nanotrasen.gov.nt"
+	var/vice_email = "vice-president@nanotrasen.gov.nt"
+	var/boss_email = "headoffice@nanotrasen.gov.nt"
+	var/rep_email = "nanotrasen@nanotrasen.gov.nt"
+	var/director_email = "director@nanotrasen.gov.nt"
+	var/investigation_email = "pdsi@nanotrasen.gov.nt"
+
+	var/minister_defense_email = "defense@nanotrasen.gov.nt"
+	var/minister_health_email = "health@nanotrasen.gov.nt"
+	var/minister_innovation_email = "innovation@nanotrasen.gov.nt"
+	var/minister_justice_email = "justice@nanotrasen.gov.nt"
+	var/minister_information_email = "information@nanotrasen.gov.nt"
+
+	var/council_email = "city-council@nanotrasen.gov.nt"
+
 /datum/map/New()
 	..()
 	if(zlevel_datum_type)

--- a/polaris.dme
+++ b/polaris.dme
@@ -354,6 +354,7 @@
 #include "code\controllers\subsystems\atoms.dm"
 #include "code\controllers\subsystems\economy.dm"
 #include "code\controllers\subsystems\elections.dm"
+#include "code\controllers\subsystems\emails.dm"
 #include "code\controllers\subsystems\events.dm"
 #include "code\controllers\subsystems\garbage.dm"
 #include "code\controllers\subsystems\holomaps.dm"


### PR DESCRIPTION
Stops email accounts from duping themselves when someone logs on.

Sadly this removes the ability to log into other people's emails when they are offline. I'll revisit this future in future.

Adds government emails and an automatic email that is sent whenever a president is elected.

![image](https://user-images.githubusercontent.com/12565163/71669097-7b305a00-2d63-11ea-8000-adfc2267c151.png)
