### PR TITLE
ATM and Accounts

### DIFF
--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -280,7 +280,7 @@ log transactions
 				scan_user(usr)
 
 				if(!ticks_left_locked_down && held_card)
-					var/tried_account_num = text2num(href_list["account_num"])
+					var/tried_account_num = href_list["account_num"]
 					if(!tried_account_num)
 						tried_account_num = held_card.associated_account_number
 					var/tried_pin = text2num(href_list["account_pin"])

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -6,7 +6,7 @@
 	var/money = 0
 	var/list/transaction_log = list()
 	var/suspended = 0
-	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
+	var/security_level = 1	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -6,7 +6,7 @@
 	var/money = 0
 	var/list/transaction_log = list()
 	var/suspended = 0
-	var/security_level = 1	//0 - auto-identify from worn ID, require only account number
+	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 
@@ -31,6 +31,7 @@
 	M.owner_name = new_owner_name
 	M.remote_access_pin = rand(1111, 9999)
 	M.money = starting_funds
+	M.security_level = 1
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -43,7 +44,7 @@
 		T.time = stationtime2text()
 		T.source_terminal = "NTGalaxyNet Terminal #[rand(111,1111)]"
 
-		M.account_number = rand(111111, 999999)
+		M.account_number = md5("[station_name()][current_date_string]")
 	else
 		T.date = current_date_string
 		T.time = stationtime2text()
@@ -85,7 +86,7 @@
 /proc/charge_to_account(var/attempt_account_number, var/source_name, var/purpose, var/terminal_id, var/amount)
 
 	for(var/datum/money_account/D in all_money_accounts)
-		if(D.account_number == text2num(attempt_account_number) && !D.suspended || D.account_number == attempt_account_number && !D.suspended)
+		if(D.account_number == attempt_account_number && !D.suspended || D.account_number == attempt_account_number && !D.suspended)
 			D.money += amount
 			//create a transaction log entry
 			var/datum/transaction/T = new()

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -125,10 +125,11 @@ var/global/list/station_departments = list("City Council", "Public Healthcare", 
 
 		station_account = new()
 		station_account.owner_name = "[station_name()] Funds"
-		station_account.account_number = rand(111111, 999999)
+		station_account.account_number = md5("[station_name()] Funds")
 		station_account.remote_access_pin = rand(1111, 9999)
 		station_account.money = 950000
 		station_account.department = "[station_name()] Funds"
+		station_account.security_level = 0
 		//create an entry in the account transaction log for when it was created
 		var/datum/transaction/T = new()
 		T.target_name = station_account.owner_name
@@ -148,10 +149,11 @@ var/global/list/station_departments = list("City Council", "Public Healthcare", 
 
 	var/datum/money_account/department_account = new()
 	department_account.owner_name = "[department] Funds Account"
-	department_account.account_number = rand(111111, 999999)
+	department_account.account_number = md5("[department] Funds Account")
 	department_account.remote_access_pin = rand(1111, 9999)
 	department_account.money = 1500
 	department_account.department = department
+	department_account.security_level = 0
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()


### PR DESCRIPTION
- Player bank accounts now start at Security Level 1, meaning that a PIN is also required to log into the account by default. Should help prevent grief in the form of draining a person's entire bank account, especially if they've gone SSD.

- Department and Station accts are generated with hash ids rather than numbers.