### PR TITLE
Horse racing terminal bugfix

### DIFF
--- a/code/game/machinery/computer/betting_terminal.dm
+++ b/code/game/machinery/computer/betting_terminal.dm
@@ -281,7 +281,7 @@
 		stored_money = 0
 
 	else if(href_list["bet"])
-		if((stored_money >= bet_cost) && can_play())
+		if((stored_money >= 100) && can_play())
 			bet(usr)
 
 	src.updateUsrDialog()


### PR DESCRIPTION
Horse racing terminals will not work with less than 100 credits, rather than less than the previous bet. 