### PR TITLE
Returns Weapons Crates to normal + Raises Cargo Prices

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -95,9 +95,8 @@ var/datum/controller/supply/supply_controller = new()
 		if(istype(MA,/obj/structure/closet/crate))
 			var/obj/structure/closet/crate/CR = MA
 			callHook("sell_crate", list(CR, area_shuttle))
-			
+
 			department_accounts["Cargo"].money += CR.points_per_crate
-			var/find_slip = 1
 
 			for(var/atom/A in CR)
 				EC.contents[++EC.contents.len] = list(
@@ -106,30 +105,11 @@ var/datum/controller/supply/supply_controller = new()
 						"quantity" = 1
 					)
 
-				// Sell manifests
-				if(find_slip && istype(A,/obj/item/weapon/paper/manifest))
-					var/obj/item/weapon/paper/manifest/slip = A
-					if(!slip.is_copy && slip.stamped && slip.stamped.len) //yes, the clown stamp will work. clown is the highest authority on the station, it makes sense
-						department_accounts["Cargo"].money += points_per_slip
-						EC.contents[EC.contents.len]["value"] = points_per_slip
-						find_slip = 0
-					continue
 
-				// Sell phoron and platinum
-				if(istype(A, /obj/item/stack))
-					var/obj/item/stack/P = A
-					if(material_points_conversion[P.get_material_name()])
-						EC.contents[EC.contents.len]["value"] = P.get_amount() * material_points_conversion[P.get_material_name()]
-					EC.contents[EC.contents.len]["quantity"] = P.get_amount()
-					EC.value += EC.contents[EC.contents.len]["value"]
-
-
-				//Sell spacebucks
-				if(istype(A, /obj/item/weapon/spacecash))
-					var/obj/item/weapon/spacecash/cashmoney = A
-					EC.contents[EC.contents.len]["value"] = cashmoney.worth * points_per_money
-					EC.contents[EC.contents.len]["quantity"] = cashmoney.worth
-					EC.value += EC.contents[EC.contents.len]["value"]
+				var/obj/sold = A
+				EC.contents[EC.contents.len]["value"] = sold.get_item_cost()
+				EC.contents[EC.contents.len]["quantity"] = 1
+				EC.value += EC.contents[EC.contents.len]["value"]
 
 
 

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -14,7 +14,7 @@
 			)
 
 	name = "Contraband crate"
-	cost = 25
+	cost = 250
 	containertype = /obj/structure/closet/crate
 	containername = "Unlabeled crate"
 	contraband = 1
@@ -27,7 +27,7 @@
 			/obj/item/weapon/grenade/smokebomb = 4,
 			/obj/item/weapon/grenade/chem_grenade/incendiary
 			)
-	cost = 25
+	cost = 500
 	containertype = /obj/structure/closet/crate
 	containername = "Special Ops crate"
 	contraband = 1
@@ -49,7 +49,7 @@
  			/obj/item/weapon/gun/projectile/shotgun/pump/rifle = 3,
  			/obj/item/ammo_magazine/clip/c762 = 6
  			)
- 	cost = 50
+ 	cost = 2500
  	contraband = 1
  	containertype = /obj/structure/closet/crate/secure/weapon
  	containername = "Ballistic weapons crate"
@@ -99,7 +99,7 @@
 					/obj/item/ammo_magazine/clip/c12g
 					)
 			)
-	cost = 2500 //very expensive to curb abuse at the factory
+	cost = 3500 //very expensive to curb abuse at the factory
 	contraband = 1
 	containertype = /obj/structure/largecrate/suspicious
 	containername = "Suspicious crate"

--- a/code/datums/supplypacks/costumes.dm
+++ b/code/datums/supplypacks/costumes.dm
@@ -18,7 +18,7 @@
 			/obj/item/clothing/shoes/sandal,
 			/obj/item/clothing/head/wizard/fake
 			)
-	cost = 20
+	cost = 300
 	containertype = /obj/structure/closet/crate
 	containername = "Wizard costume crate"
 
@@ -47,7 +47,7 @@
 			/obj/item/clothing/head/collectable/petehat
 			)
 	name = "Collectable hat crate!"
-	cost = 200
+	cost = 100
 	containertype = /obj/structure/closet/crate
 	containername = "Collectable hats crate! Brought to you by Bass.inc!"
 
@@ -83,7 +83,7 @@
 			/obj/item/clothing/under/kilt
 			)
 	name = "Costumes crate"
-	cost = 10
+	cost = 200
 	containertype = /obj/structure/closet/crate
 	containername = "Actor Costumes"
 
@@ -105,7 +105,7 @@
 			/obj/item/clothing/accessory/wcoat
 			)
 	name = "Formalwear closet"
-	cost = 30
+	cost = 450
 	containertype = /obj/structure/closet
 	containername = "Formalwear for the best occasions."
 
@@ -113,7 +113,7 @@ datum/supply_pack/costumes/witch
 	name = "Witch costume"
 	containername = "Witch costume"
 	containertype = /obj/structure/closet
-	cost = 20
+	cost = 50
 	contains = list(
 			/obj/item/clothing/suit/wizrobe/marisa/fake,
 			/obj/item/clothing/shoes/sandal,
@@ -125,7 +125,7 @@ datum/supply_pack/costumes/witch
 	name = "Costume hats"
 	containername = "Actor hats crate"
 	containertype = /obj/structure/closet/crate
-	cost = 10
+	cost = 70
 	num_contained = 3
 	contains = list(
 			/obj/item/clothing/head/redcoat,
@@ -150,7 +150,7 @@ datum/supply_pack/costumes/witch
 	name = "Womens formal dress locker"
 	containername = "Pretty dress locker"
 	containertype = /obj/structure/closet
-	cost = 15
+	cost = 450
 	num_contained = 3
 	contains = list(
 			/obj/item/clothing/under/wedding/bride_orange,

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -10,7 +10,7 @@
 /datum/supply_pack/eng/lightbulbs
 	name = "Replacement lights"
 	contains = list(/obj/item/weapon/storage/box/lights/mixed = 3)
-	cost = 10
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "Replacement lights"
 
@@ -38,28 +38,28 @@
 /datum/supply_pack/eng/bubble_shield
 	name = "Bubble Shield Generator"
 	contains = list(/obj/machinery/shield_gen)
-	cost = 40
+	cost = 400
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "shield bubble generator crate"
 
 /datum/supply_pack/eng/bubble_shield/advanced
 	name = "Advanced Bubble Shield Generator"
 	contains = list(/obj/machinery/shield_gen/advanced)
-	cost = 60
+	cost = 600
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "advanced bubble shield generator crate"
 
 /datum/supply_pack/eng/hull_shield
 	name = "Hull Shield Generator"
 	contains = list(/obj/machinery/shield_gen/external)
-	cost = 80
+	cost = 900
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "shield hull generator crate"
 
 /datum/supply_pack/eng/hull_shield/advanced
 	name = "Advanced Hull Shield Generator"
 	contains = list(/obj/machinery/shield_gen/external/advanced)
-	cost = 120
+	cost = 1200
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "advanced hull shield generator crate"
 
@@ -71,7 +71,7 @@
 			/obj/item/weapon/cell = 2,
 			/obj/item/weapon/cell/high = 2
 			)
-	cost = 10
+	cost = 30
 	containertype = /obj/structure/closet/crate/engineering/electrical
 	containername = "Electrical maintenance crate"
 
@@ -80,7 +80,7 @@
 	contains = list(
 			/obj/item/weapon/weldingtool/electric = 3
 			)
-	cost = 15
+	cost = 20
 	containertype = /obj/structure/closet/crate/engineering/electrical
 	containername = "Electric welder crate"
 
@@ -92,7 +92,7 @@
 			/obj/item/clothing/head/welding = 2,
 			/obj/item/clothing/head/hardhat
 			)
-	cost = 10
+	cost = 30
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "Mechanical maintenance crate"
 /*
@@ -118,7 +118,7 @@
 /datum/supply_pack/eng/engine
 	name = "Emitter crate"
 	contains = list(/obj/machinery/power/emitter = 2)
-	cost = 10
+	cost = 100
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "Emitter crate"
 	access = access_ce
@@ -162,7 +162,7 @@
 /datum/supply_pack/eng/shield_gen
 	contains = list(/obj/item/weapon/circuitboard/shield_gen)
 	name = "Bubble shield generator circuitry"
-	cost = 30
+	cost = 300
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "bubble shield generator circuitry crate"
 	access = access_ce
@@ -170,7 +170,7 @@
 /datum/supply_pack/eng/shield_gen_ex
 	contains = list(/obj/item/weapon/circuitboard/shield_gen_ex)
 	name = "Hull shield generator circuitry"
-	cost = 30
+	cost = 300
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "hull shield generator circuitry crate"
 	access = access_ce
@@ -178,7 +178,7 @@
 /datum/supply_pack/eng/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
 	name = "Bubble shield capacitor circuitry"
-	cost = 30
+	cost = 300
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "shield capacitor circuitry crate"
 	access = access_ce
@@ -194,7 +194,7 @@
 /datum/supply_pack/eng/teg
 	contains = list(/obj/machinery/power/generator)
 	name = "Mark I Thermoelectric Generator"
-	cost = 40
+	cost = 400
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "Mk1 TEG crate"
 	access = access_engine
@@ -202,7 +202,7 @@
 /datum/supply_pack/eng/circulator
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
 	name = "Binary atmospheric circulator"
-	cost = 20
+	cost = 200
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "Atmospheric circulator crate"
 	access = access_engine
@@ -213,13 +213,13 @@
 			/obj/item/clothing/head/radiation = 3
 			)
 	name = "Radiation suits package"
-	cost = 20
+	cost = 200
 	containertype = /obj/structure/closet/radiation
 	containername = "Radiation suit locker"
 
 /datum/supply_pack/eng/pacman_parts
 	name = "P.A.C.M.A.N. portable generator parts"
-	cost = 25
+	cost = 250
 	containername = "P.A.C.M.A.N. Portable Generator Construction Kit"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_tech_storage
@@ -232,7 +232,7 @@
 
 /datum/supply_pack/eng/super_pacman_parts
 	name = "Super P.A.C.M.A.N. portable generator parts"
-	cost = 35
+	cost = 350
 	containername = "Super P.A.C.M.A.N. portable generator construction kit"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_tech_storage
@@ -245,7 +245,7 @@
 
 /datum/supply_pack/eng/fusion_core
 	name = "R-UST Mk. 8 Tokamak fusion core crate"
-	cost = 50
+	cost = 500
 	containername = "R-UST Mk. 8 Tokamak Fusion Core crate"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_engine
@@ -257,7 +257,7 @@
 
 /datum/supply_pack/eng/fusion_fuel_injector
 	name = "R-UST Mk. 8 fuel injector crate"
-	cost = 30
+	cost = 300
 	containername = "R-UST Mk. 8 fuel injector crate"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_engine
@@ -269,7 +269,7 @@
 
 /datum/supply_pack/eng/gyrotron
 	name = "Gyrotron crate"
-	cost = 15
+	cost = 150
 	containername = "Gyrotron Crate"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_engine
@@ -280,14 +280,14 @@
 
 /datum/supply_pack/eng/fusion_fuel_compressor
 	name = "Fusion Fuel Compressor circuitry crate"
-	cost = 10
+	cost = 100
 	containername = "Fusion Fuel Compressor circuitry crate"
 	containertype = /obj/structure/closet/crate/engineering
 	contains = list(/obj/item/weapon/circuitboard/fusion_fuel_compressor)
 
 /datum/supply_pack/eng/tritium
 	name = "Tritium crate"
-	cost = 75
+	cost = 750
 	containername = "Tritium crate"
 	containertype = /obj/structure/closet/crate/engineering
 	contains = list(/obj/fiftyspawner/tritium)

--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -22,7 +22,7 @@
 			/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale = 2,
 			/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer = 4,
 			)
-	cost = 10
+	cost = 100
 	containertype = /obj/structure/closet/crate
 	containername = "Party equipment"
 
@@ -42,7 +42,7 @@
 			/obj/item/weapon/storage/box/glass_extras/straws,
 			/obj/item/weapon/storage/box/glass_extras/sticks
 			)
-	cost = 10
+	cost = 100
 	containertype = /obj/structure/closet/crate
 	containername = "crate of bar supplies"
 
@@ -58,7 +58,7 @@
 			/obj/item/pizzabox/vegetable
 			)
 	name = "Surprise pack of five pizzas"
-	cost = 15
+	cost = 45
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Pizza crate"
 
@@ -72,6 +72,6 @@
 		/obj/item/weapon/paper/card/cat,
 		/obj/item/weapon/paper/card/flower
 		)
-	cost = 10
+	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "crate of gifts"

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -10,10 +10,10 @@
 /datum/supply_pack/hydro/monkey
 	name = "Monkey crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
-	cost = 20
+	cost = 80
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Monkey crate"
-
+/*
 /datum/supply_pack/hydro/farwa
 	name = "Farwa crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/farwacubes)
@@ -34,11 +34,11 @@
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Stok crate"
-
+*/
 /datum/supply_pack/hydro/lisa
 	name = "Corgi Crate"
 	contains = list()
-	cost = 50
+	cost = 70
 	containertype = /obj/structure/largecrate/animal/corgi
 	containername = "Corgi Crate"
 
@@ -55,21 +55,21 @@
 			/obj/item/weapon/material/minihoe,
 			/obj/item/weapon/storage/box/botanydisk
 			)
-	cost = 20
+	cost = 150
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "Hydroponics crate"
 	access = access_hydroponics
 
 /datum/supply_pack/hydro/cow
 	name = "Cow crate"
-	cost = 25
+	cost = 70
 	containertype = /obj/structure/largecrate/animal/cow
 	containername = "Cow crate"
 	access = access_hydroponics
 
 /datum/supply_pack/hydro/goat
 	name = "Goat crate"
-	cost = 25
+	cost = 60
 	containertype = /obj/structure/largecrate/animal/goat
 	containername = "Goat crate"
 	access = access_hydroponics
@@ -102,7 +102,7 @@
 			/obj/item/seeds/potatoseed,
 			/obj/item/seeds/sugarcaneseed
 			)
-	cost = 10
+	cost = 100
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "Seeds crate"
 	access = access_hydroponics
@@ -124,7 +124,7 @@
 /datum/supply_pack/hydro/watertank
 	name = "Water tank crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 10
+	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
 
@@ -136,14 +136,14 @@
 			/obj/item/honey_frame = 5,
 			/obj/item/bee_pack
 			)
-	cost = 40
+	cost = 120
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "Beekeeping crate"
 	access = access_hydroponics
 
 /datum/supply_pack/hydro/tray
 	name = "Empty hydroponics trays"
-	cost = 50
+	cost = 150
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "Hydroponics tray crate"
 	contains = list(/obj/machinery/portable_atmospherics/hydroponics{anchored = 0} = 3)

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -10,35 +10,28 @@
 /datum/supply_pack/materials/metal50
 	name = "50 metal sheets"
 	contains = list(/obj/fiftyspawner/steel)
-	cost = 10
+	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "Metal sheets crate"
 
 /datum/supply_pack/materials/glass50
 	name = "50 glass sheets"
 	contains = list(/obj/fiftyspawner/glass)
-	cost = 10
+	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "Glass sheets crate"
-
-/datum/supply_pack/materials/wood50
-	name = "50 wooden planks"
-	contains = list(/obj/fiftyspawner/wood)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "Wooden planks crate"
 
 /datum/supply_pack/materials/plastic50
 	name = "50 plastic sheets"
 	contains = list(/obj/fiftyspawner/plastic)
-	cost = 10
+	cost = 60
 	containertype = /obj/structure/closet/crate
 	containername = "Plastic sheets crate"
 
 /datum/supply_pack/materials/cardboard_sheets
 	contains = list(/obj/fiftyspawner/cardboard)
 	name = "50 cardboard sheets"
-	cost = 10
+	cost = 60
 	containertype = /obj/structure/closet/crate
 	containername = "Cardboard sheets crate"
 
@@ -46,7 +39,7 @@
 	name = "Imported carpet"
 	containertype = /obj/structure/closet/crate
 	containername = "Imported carpet crate"
-	cost = 15
+	cost = 50
 	contains = list(
 					/obj/fiftyspawner/carpet,
 					/obj/fiftyspawner/tealcarpet
@@ -56,31 +49,31 @@
 /datum/supply_pack/materials/wood50
 	name = "50 wooden planks"
 	contains = list(/obj/item/stack/material/wood/fifty)
-	cost = 10
+	cost = 60
 	containername = "wooden planks crate"
 
 /datum/supply_pack/materials/mahogany25
 	name = "25 mahogany planks"
 	contains = list(/obj/item/stack/material/wood/mahogany/twentyfive)
-	cost = 10
+	cost = 30
 	containername = "wooden planks crate"
 
 /datum/supply_pack/materials/maple25
 	name = "25 maple planks"
 	contains = list(/obj/item/stack/material/wood/maple/twentyfive = 2)
-	cost = 10
+	cost = 50
 	containername = "wooden planks crate"
 
 /datum/supply_pack/materials/walnut25
 	name = "25 walnut planks"
 	contains = list(/obj/item/stack/material/wood/walnut/twentyfive)
-	cost = 10
+	cost = 50
 	containername = "walnut planks crate"
 
 /datum/supply_pack/materials/ebony25
 	name = "25 ebony planks"
 	contains = list(/obj/item/stack/material/wood/ebony/twentyfive)
-	cost = 15 //luxury tax
+	cost = 55 //luxury tax
 	containername = "ebony planks crate"
 
 

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -21,7 +21,7 @@
 			/obj/item/weapon/storage/box/syringes,
 			/obj/item/weapon/storage/box/autoinjectors
 			)
-	cost = 10
+	cost = 200
 	containertype = /obj/structure/closet/crate/medical
 	containername = "Medical crate"
 
@@ -96,7 +96,7 @@
 			/obj/item/weapon/storage/box/gloves,
 			/obj/item/weapon/storage/belt/medical = 3
 			)
-	cost = 10
+	cost = 30
 	containertype = "/obj/structure/closet/crate"
 	containername = "Sterile equipment crate"
 
@@ -108,7 +108,7 @@
 			/obj/item/device/radio/headset/headset_med/alt = 3,
 			/obj/item/clothing/suit/storage/hooded/wintercoat/medical = 3
 			)
-	cost = 10
+	cost = 30
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical surplus equipment"
 	access = access_medical
@@ -155,7 +155,7 @@
 			/obj/item/device/flashlight/pen,
 			/obj/item/weapon/reagent_containers/syringe
 			)
-	cost = 20
+	cost = 40
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical Doctor equipment"
 	access = access_medical_equip
@@ -178,7 +178,7 @@
 			/obj/item/weapon/storage/box/pillbottles,
 			/obj/item/weapon/reagent_containers/syringe
 			)
-	cost = 20
+	cost = 80
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Chemist equipment"
 	access = access_chemistry
@@ -206,7 +206,7 @@
 			/obj/item/weapon/reagent_containers/syringe,
 			/obj/item/clothing/accessory/storage/white_vest
 			)
-	cost = 20
+	cost = 90
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Paramedic equipment"
 	access = access_medical_equip
@@ -225,7 +225,7 @@
 			/obj/item/weapon/pen,
 			/obj/item/weapon/cartridge/medical
 			)
-	cost = 20
+	cost = 50
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Psychiatrist equipment"
 	access = access_psychiatrist
@@ -246,7 +246,7 @@
 			/obj/item/weapon/storage/box/masks,
 			/obj/item/weapon/storage/box/gloves
 			)
-	cost = 10
+	cost = 40
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical scrubs crate"
 	access = access_medical_equip
@@ -263,7 +263,7 @@
 			/obj/item/weapon/storage/box/gloves,
 			/obj/item/weapon/pen
 			)
-	cost = 20
+	cost = 30
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Autopsy equipment crate"
 	access = access_morgue
@@ -290,7 +290,7 @@
 			/obj/item/weapon/storage/box/masks,
 			/obj/item/weapon/storage/box/gloves
 			)
-	cost = 10
+	cost = 40
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical uniform crate"
 	access = access_medical_equip
@@ -308,7 +308,7 @@
 			/obj/item/weapon/storage/box/masks,
 			/obj/item/weapon/storage/box/gloves
 			)
-	cost = 50
+	cost = 40
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical biohazard equipment"
 	access = access_medical_equip
@@ -316,7 +316,7 @@
 /datum/supply_pack/med/portablefreezers
 	name = "Portable freezers crate"
 	contains = list(/obj/item/weapon/storage/box/freezer = 7)
-	cost = 25
+	cost = 45
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Portable freezers"
 	access = access_medical_equip
@@ -324,7 +324,7 @@
 /datum/supply_pack/med/virus
 	name = "Virus sample crate"
 	contains = list(/obj/item/weapon/virusdish/random = 4)
-	cost = 25
+	cost = 45
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Virus sample crate"
 	access = access_cmo
@@ -332,6 +332,6 @@
 /datum/supply_pack/med/defib
 	name = "Defibrillator crate"
 	contains = list(/obj/item/device/defib_kit = 2)
-	cost = 30
+	cost = 40
 	containertype = /obj/structure/closet/crate/medical
 	containername = "Defibrillator crate"

--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -51,7 +51,7 @@
 /datum/supply_pack/misc/hoverpod
 	name = "Hoverpod Shipment"
 	contains = list()
-	cost = 80
+	cost = 800
 	containertype = /obj/structure/largecrate/hoverpod
 	containername = "Hoverpod Crate"
 
@@ -67,7 +67,7 @@
 			/obj/item/clothing/accessory/storage/white_drop_pouches,
 			/obj/item/clothing/accessory/storage/webbing
 			)
-	cost = 10
+	cost = 30
 	containertype = "/obj/structure/closet/crate"
 	containername = "Webbing crate"
 
@@ -83,7 +83,7 @@
 	contains = list(
 	/obj/item/device/camera,
 	/obj/item/device/camera_film = 2)
-	cost = 300
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "Journalism Kit"
 
@@ -91,6 +91,6 @@
 	name = "Camera Film Refills"
 	contains = list(
 	/obj/item/device/camera_film = 5)
-	cost = 230
+	cost = 15
 	containertype = /obj/structure/closet/crate
 	containername = "Camera Film Refills"

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -19,7 +19,7 @@
 			/obj/item/weapon/gun/projectile/colt/detective = 2,
 			/obj/item/weapon/storage/box/flashbangs = 2
 			)
-	cost = 40
+	cost = 95
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Security equipment crate"
 	access = access_security
@@ -27,7 +27,7 @@
 /datum/supply_pack/munitions/egunpistol
 	name = "Weapons - Energy sidearms"
 	contains = list(/obj/item/weapon/gun/energy/gun = 2)
-	cost = 40
+	cost = 400
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Energy sidearms crate"
 	access = access_security
@@ -40,7 +40,7 @@
 			/obj/item/weapon/gun/projectile/shotgun/doublebarrel/flare,
 			/obj/item/weapon/storage/box/flashshells
 			)
-	cost = 25
+	cost = 250
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Flare gun crate"
 	access = access_security
@@ -50,7 +50,7 @@
 	contains = list(
 			/obj/item/weapon/gun/energy/xray = 2,
 			/obj/item/weapon/shield/energy = 2)
-	cost = 100
+	cost = 600
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "Experimental weapons crate"
 	access = access_armory
@@ -58,7 +58,7 @@
 /datum/supply_pack/munitions/energyweapons
 	name = "Weapons - Laser rifle crate"
 	contains = list(/obj/item/weapon/gun/energy/laser = 3)
-	cost = 50
+	cost = 160
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Energy weapons crate"
 	access = access_armory
@@ -70,7 +70,7 @@
 			/obj/item/weapon/storage/box/shotgunshells,
 			/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2
 			)
-	cost = 50
+	cost = 215
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Shotgun crate"
 	access = access_armory
@@ -86,7 +86,7 @@
 /datum/supply_pack/munitions/burstlaser
 	name = "Weapons - Burst laser"
 	contains = list(/obj/item/weapon/gun/energy/gun/burst = 2)
-	cost = 50
+	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Burst laser crate"
 	access = access_armory
@@ -97,7 +97,7 @@
 			/obj/item/weapon/gun/energy/ionrifle = 2,
 			/obj/item/weapon/storage/box/empslite
 			)
-	cost = 50
+	cost = 150
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Electromagnetic weapons crate"
 	access = access_armory
@@ -108,7 +108,7 @@
 			/obj/item/weapon/gun/energy/ionrifle/pistol = 2,
 			/obj/item/weapon/storage/box/empslite
 			)
-	cost = 30
+	cost = 130
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Electromagnetic weapons crate"
 	access = access_armory
@@ -116,7 +116,7 @@
 /datum/supply_pack/munitions/bsmg
 	name = "Weapons - Ballistic SMGs"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550 = 2)
-	cost = 50
+	cost = 450
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Ballistic weapon crate"
 	access = access_armory
@@ -124,7 +124,7 @@
 /datum/supply_pack/munitions/brifle
 	name = "Weapons - Ballistic Rifles"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/z8 = 2)
-	cost = 80
+	cost = 280
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Ballistic weapon crate"
 	access = access_armory
@@ -139,7 +139,7 @@
  			/obj/item/target/alien = 2,
  			/obj/item/target/syndicate = 2
  			)
- 	cost = 40
+ 	cost = 140
  	containertype = /obj/structure/closet/crate/secure/weapon
  	containername = "Ballistic weapons crate"
  	access = access_security

--- a/code/datums/supplypacks/voidsuits.dm
+++ b/code/datums/supplypacks/voidsuits.dm
@@ -16,7 +16,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2,
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Atmospheric voidsuit crate"
 	access = access_atmospherics
@@ -30,7 +30,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2,
 			)
-	cost = 50
+	cost = 250
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Heavy Duty Atmospheric voidsuit crate"
 	access = access_atmospherics
@@ -44,7 +44,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Engineering voidsuit crate"
 	access = access_engine_equip
@@ -58,7 +58,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Engineering Construction voidsuit crate"
 	access = access_engine_equip
@@ -72,7 +72,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 45
+	cost = 245
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Engineering Hazmat voidsuit crate"
 	access = access_engine_equip
@@ -86,7 +86,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 250
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Reinforced Engineering voidsuit crate"
 	access = access_engine_equip
@@ -100,7 +100,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical voidsuit crate"
 	access = access_medical_equip
@@ -114,7 +114,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical EMT voidsuit crate"
 	access = access_medical_equip
@@ -128,7 +128,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 45
+	cost = 245
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Medical Biohazard voidsuit crate"
 	access = access_medical_equip
@@ -142,7 +142,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 60
+	cost = 260
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Vey-Med Medical voidsuit crate"
 	access = access_medical_equip
@@ -156,7 +156,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Security voidsuit crate"
 
@@ -169,7 +169,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Security Crowd Control voidsuit crate"
 	access = access_armory
@@ -183,7 +183,7 @@
 			/obj/item/clothing/shoes/magboots = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 250
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Security EVA Riot voidsuit crate"
 	access = access_armory
@@ -196,7 +196,7 @@
 			/obj/item/clothing/mask/breath = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 40
+	cost = 240
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Mining voidsuit crate"
 	access = access_mining
@@ -209,7 +209,7 @@
 			/obj/item/clothing/mask/breath = 2,
 			/obj/item/weapon/tank/oxygen = 2
 			)
-	cost = 50
+	cost = 250
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "Frontier Mining voidsuit crate"
 	access = access_mining

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -340,7 +340,6 @@
 	icon_state = "weaponcrate"
 	icon_opened = "weaponcrateopen"
 	icon_closed = "weaponcrate"
-	health = 90000
 
 /obj/structure/closet/crate/secure/phoron
 	name = "phoron crate"

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -18,6 +18,9 @@
 	drop_sound = 'sound/items/drop/paper.ogg'
 	var/list/possible_values = list(100,50,20,10,5,2,1)
 
+/obj/item/weapon/spacecash/get_item_cost()
+	return worth	// lol
+
 /obj/item/weapon/spacecash/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/spacecash))
 		if(istype(W, /obj/item/weapon/spacecash/ewallet)) return 0

--- a/code/modules/government/law/_law_vars.dm
+++ b/code/modules/government/law/_law_vars.dm
@@ -18,7 +18,7 @@
 	if(police_record)
 		var/list/criminal_record = police_record.fields["crim_record"]
 		if(!isemptylist(criminal_record))
-			return "criminal"
+			return 0
 
 	return 1
 

--- a/code/modules/government/law/_law_vars.dm
+++ b/code/modules/government/law/_law_vars.dm
@@ -4,7 +4,7 @@
 	if(!ishuman(H))
 		return 0
 
-	if(!(persistent_economy.voting_age >= H.age) )
+	if(!(persistent_economy.voting_age > H.age) )
 		return 0
 
 	if(!persistent_economy.synth_vote && H.isSynthetic() )
@@ -18,7 +18,7 @@
 	if(police_record)
 		var/list/criminal_record = police_record.fields["crim_record"]
 		if(!isemptylist(criminal_record))
-			return 0
+			return "criminal"
 
 	return 1
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -364,7 +364,7 @@
 	if(istype(O,/obj/item/stack))
 		var/obj/item/stack/stack = O
 
-		if(!(stack.associated_reagent && stack.reagents.total_volume))
+		if(!(!isemptylist(stack.associated_reagents) && stack.reagents.total_volume))
 			user << "\The [O] is not suitable for blending."
 
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -207,7 +207,7 @@
 	taste_description = "metal"
 	reagent_state = SOLID
 	color = "#F7C430"
-	price_tag = 2.2
+	price_tag = 3.2
 
 /datum/reagent/silver
 	name = "Silver"
@@ -414,7 +414,7 @@
 	taste_description = "slime"
 	reagent_state = LIQUID
 	color = "#009CA8"
-	price_tag = 0.2
+	price_tag = 0.7
 
 /datum/reagent/lube/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
@@ -445,6 +445,7 @@
 	taste_description = "sweetness"
 	reagent_state = LIQUID
 	color = "#808080"
+	price_tag = 0.9
 
 /datum/reagent/nitroglycerin
 	name = "Nitroglycerin"
@@ -453,6 +454,7 @@
 	taste_description = "oil"
 	reagent_state = LIQUID
 	color = "#808080"
+	price_tag = 0.7
 
 /datum/reagent/coolant
 	name = "Coolant"
@@ -462,6 +464,7 @@
 	taste_mult = 1.1
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	price_tag = 0.5
 
 /datum/reagent/ultraglue
 	name = "Ultra Glue"
@@ -469,6 +472,7 @@
 	description = "An extremely powerful bonding agent."
 	taste_description = "a special education class"
 	color = "#FFFFCC"
+	price_tag = 0.5
 
 /datum/reagent/woodpulp
 	name = "Wood Pulp"
@@ -477,6 +481,7 @@
 	taste_description = "wood"
 	reagent_state = LIQUID
 	color = "#B97A57"
+	price_tag = 0.9
 
 /datum/reagent/luminol
 	name = "Luminol"
@@ -536,7 +541,7 @@
 	taste_description = "a bitter gooey substance"
 	reagent_state = LIQUID
 	color = "#755202"
-	price_tag = 0.8
+	price_tag = 1.8
 
 	get_tax()
 		return DRUG_TAX
@@ -548,7 +553,7 @@
 	taste_description = "a bitter gooey substance"
 	reagent_state = LIQUID
 	color = "#755202"
-	price_tag = 0.8
+	price_tag = 1.8
 
 	get_tax()
 		return DRUG_TAX


### PR DESCRIPTION
Weapon crates returned to normal health, in exchange, the price is heightened into the thousands, as it should be.

You can now ship any item, as long as it has a price tag (the type that's compatible with the atm), it will give you money as long as you send it in a crate.

Money now returns its own worth. V cool.

All things in cargo get price rises.