### PR TITLE
Coffee Expansion (Work in progress)

### DIFF
--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -18,6 +18,24 @@
 	outfit_type = /decl/hierarchy/outfit/job/service/bartender
 	alt_titles = list("Waiting Staff","Barkeep","Mixologist","Barista" = /decl/hierarchy/outfit/job/service/bartender/barista)
 
+/datum/job/barista
+	title = "Barista"
+	flag = BARISTA
+	faction = "City"
+	department "Bar"
+	department_flag = CIVILIAN
+	total_positions = 2
+	spawn_positions = 2
+	email_domain = "foodstuffs.nt"
+	supervisors = "the city clerk"
+	selection_color = "#515151"
+	idtype = /obj/item/weapon/card/id/civilian/barista
+	access = list(access_coffee, access_bar, access_kitchen)
+	minimal_access = list("access_coffee")
+	minimum_character_age = 14
+	wage = 15
+	outfit_type = /decl/hierarchy/outfit/job/service/bartender/barista
+	alt_titles = list("Soda Jerk")
 
 /datum/job/chef
 	title = "Chef"


### PR DESCRIPTION
Drinks are a port from [Baystation](https://github.com/Baystation12/Baystation12/pull/27410):

### What this PR does 
**Beverages:**
- Rooibos tea, chai tea, chai latte, london fog, and mocha latte as dispensable/mixable drinks.
- Chocolate, vanilla, caramel, and pumpkin spice syrups for flavoring.

**Cafe:**
- Adds a coffeehouse, attached to kitchen/bar.
- ~~Makes barista a separate role, with "Soda Jerk" alt title.~~ Just adds a "Soda Jerk" alt title to Bartender