### PR TITLE
Pianos now support longer songs

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -396,11 +396,11 @@
 				if (!in_range(src, usr))
 					return
 
-				if(lentext(t) >= 3072)
+				if(lentext(t) >= 5563)
 					var/cont = input(usr, "Your message is too long! Would you like to continue editing it?", "", "yes") in list("yes", "no")
 					if(cont == "no")
 						break
-			while(lentext(t) > 3072)
+			while(lentext(t) > 5563)
 
 			//split into lines
 			spawn()
@@ -409,9 +409,9 @@
 				if(copytext(lines[1],1,6) == "BPM: ")
 					tempo = 600 / text2num(copytext(lines[1],6))
 					lines.Cut(1,2)
-				if(lines.len > 50)
+				if(lines.len > 150)
 					usr << "Too many lines!"
-					lines.Cut(51)
+					lines.Cut(151)
 				var/linenum = 1
 				for(var/l in lines)
 					if(lentext(l) > 50)


### PR DESCRIPTION
The piano line limit has been increased from 50 lines to 150 lines.

It can now support the longest of songs across the ss13 wikis. Line limit chosen based on longest song I could find which I believe to be Pewdiepie's "Bitch Lasagna" at 130 lines. This equates to about 2-3 minutes of continuous piano playing at 150 bpm.