### PR TITLE
Fixes knocked out borgs never dying.

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -103,9 +103,8 @@
 
 		AdjustConfused(-1)
 
-	else //Dead.
+	else //Dead or just unconscious.
 		src.blinded = 1
-		src.stat = 2
 
 	if (src.stuttering) src.stuttering--
 


### PR DESCRIPTION
"Fixes the borg life code making it so that a hiccup while applying any unconscious stat (1) on borgs would permanently force their stat into 2(dead), which from that point onward will just skip the death proc when it eventually would become relevant."

Port from Polaris