### PR TITLE
Makes chemmasters constructable

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/other.dm
+++ b/code/game/objects/items/weapons/circuitboards/other.dm
@@ -8,3 +8,10 @@
 	name = T_BOARD("AI core")
 	origin_tech = list(TECH_DATA = 4, TECH_BIO = 2)
 	board_type = "other"
+	
+/obj/item/weapon/circuitboard/chem_master
+	name = T_BOARD("ChemMaster 3000")
+	build_path = /obj/machinery/chem_master
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 2)
+	req_components = list()

--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -355,6 +355,7 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 		/obj/item/weapon/circuitboard/jukebox,
 		/obj/item/weapon/circuitboard/message_monitor,
 		/obj/item/weapon/circuitboard/rcon_console,
+		/obj/item/weapon/circuitboard/chem_master,
 		/obj/item/weapon/smes_coil,
 		/obj/item/weapon/cartridge/engineering,
 		/obj/item/device/analyzer,

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -4,6 +4,7 @@
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mixer0"
+	circuit = /obj/item/weapon/circuitboard/chem_master
 	use_power = 1
 	idle_power_usage = 20
 	var/beaker = null

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -63,7 +63,11 @@
 
 	else if(default_unfasten_wrench(user, B, 20))
 		return
-
+	if(default_deconstruction_screwdriver(user, B))
+		return
+	if(default_deconstruction_crowbar(user, B))
+		return
+		
 	return
 
 /obj/machinery/chem_master/attack_hand(mob/user as mob)

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -590,6 +590,13 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/aicore
 	sort_string = "XAAAA"
 
+/datum/design/circuit/chem_master
+	name = "ChemMaster 3000"
+	id = "chemmaster"
+	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2)
+	build_path = /obj/item/weapon/circuitboard/chem_master
+	sort_string = "FAGAH"
+
 
 /* I have no idea how this was even running before, but it doesn't seem to be necessary.
 ///////////////////////////////////


### PR DESCRIPTION
* Makes chemmasters constructable and deconstructable.
* Chem masters circuits can be made in science.
* Circuits for chem masters can also be found in loot piles.