### PR TITLE
Allows Alternative to DB for Player Age Logging

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -83,17 +83,17 @@ var/next_station_date_change = 1 DAY
 	game_minute = (text2num(game_minute))
 	return game_minute
 
-/proc/get_year()
+/proc/get_real_year()
 	var/year = (time2text(world.timeofday, "YYYY"))
-	year = (text2num(year)) + config.years_in_future
+	year = (text2num(year))
 	return year
 
-/proc/get_month()
+/proc/get_real_month()
 	var/month = (time2text(world.timeofday, "MM"))
-	month = (text2num(month)) + config.months_in_future
+	month = (text2num(month))
 	return month
 
-/proc/get_day()
+/proc/get_real_day()
 	var/day = (time2text(world.timeofday, "DD"))
 	day = (text2num(day))
 	return day
@@ -101,6 +101,8 @@ var/next_station_date_change = 1 DAY
 /proc/full_game_time()
 	return "[get_game_day()]/[get_game_month()]/[get_game_year()]"
 
+/proc/full_real_time()
+	return "[get_real_day()]/[get_real_month()]/[get_real_year()]"
 
 //ISO 8601
 /proc/time_stamp()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -28,6 +28,7 @@ var/list/gamemode_cache = list()
 	var/log_runtime = 0					// logs world.log to a file
 	var/log_world_output = 0			// log world.log << messages
 	var/sql_enabled = 0					// for sql switching
+	var/hard_saving = 1				// If database decides to fail, do we save things to file?
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/ert_admin_call_only = 0
@@ -313,6 +314,9 @@ var/list/gamemode_cache = list()
 
 				if ("sql_enabled")
 					config.sql_enabled = 1
+
+				if ("hard_saving")
+					config.hard_saving = 1
 
 				if ("log_say")
 					config.log_say = 1

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -51,9 +51,6 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
-	var/first_seen
-	var/last_seen
-
 	preload_rsc = PRELOAD_RSC
 
 	var/global/obj/screen/click_catcher/void

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -51,6 +51,9 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
+	var/first_seen
+	var/last_seen
+
 	preload_rsc = PRELOAD_RSC
 
 	var/global/obj/screen/click_catcher/void

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -200,8 +200,8 @@
 /proc/get_player_age(key)
 	establish_db_connection()
 	if(!dbcon.IsConnected())
-		if(config.hard_saving && get_mob_by_key(ckey))
-			return hard_save_player_age(ckey)
+		if(config.hard_saving && get_mob_by_key(key))
+			return hard_save_player_age(key)
 		else
 			return null
 
@@ -221,11 +221,11 @@
 
 	if(config.hard_saving)
 		if(!M.client.prefs.first_seen)
-			prefs.first_seen = full_game_time()
-		if(!prefs.last_seen)
-			prefs.last_seen = full_game_time()
+			M.client.prefs.first_seen = full_game_time()
+		if(!M.client.prefs.last_seen)
+			M.client.prefs.last_seen = full_game_time()
 
-		return Days_Difference(prefs.first_seen , prefs.last_seen)
+		return Days_Difference(M.client.prefs.first_seen , M.client.prefs.last_seen)
 
 
 /client/proc/log_client_to_db()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -155,10 +155,10 @@
 			winset(src, null, "command=\".configure graphics-hwmode off\"")
 			sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
 			winset(src, null, "command=\".configure graphics-hwmode on\"")
-	if(!first_seen)
-		first_seen = full_game_time()
-	if(!last_seen)
-		last_seen = full_game_time()
+	if(!prefs.first_seen)
+		prefs.first_seen = full_game_time()
+	if(!prefs.last_seen)
+		prefs.last_seen = full_game_time()
 
 	log_client_to_db()
 
@@ -199,26 +199,30 @@
 
 /proc/get_player_age(key)
 	establish_db_connection()
-	if(dbcon.IsConnected())
-		var/sql_ckey = sql_sanitize_text(ckey(key))
+	if(!dbcon.IsConnected())
+		return null
 
-		var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age FROM erro_player WHERE ckey = '[sql_ckey]'")
-		query.Execute()
+	var/sql_ckey = sql_sanitize_text(ckey(key))
 
-		if(query.NextRow())
-			return text2num(query.item[1])
-		else
-			return -1
+	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age FROM erro_player WHERE ckey = '[sql_ckey]'")
+	query.Execute()
+
+	if(query.NextRow())
+		return text2num(query.item[1])
 	else
-		if(config.hard_saving)
-			if(!pref.first_seen)
-				pref.first_seen = full_game_time()
-			if(!pref.last_seen)
-				pref.last_seen = full_game_time()
-			
-			return Days_Difference(first_seen , last_seen)
+		return -1
+		
+/proc/hard_save_player_age(mob/M)
+	if(!M || !M.client || !M.client.prefs))
+		return 0
 
+	if(config.hard_saving)
+		if(!M.client.prefs.first_seen)
+			prefs.first_seen = full_game_time()
+		if(!prefs.last_seen)
+			prefs.last_seen = full_game_time()
 
+		return Days_Difference(prefs.first_seen , prefs.last_seen)
 
 
 /client/proc/log_client_to_db()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -200,7 +200,10 @@
 /proc/get_player_age(key)
 	establish_db_connection()
 	if(!dbcon.IsConnected())
-		return null
+		if(config.hard_saving && get_mob_by_key(ckey))
+			return hard_save_player_age(ckey)
+		else
+			return null
 
 	var/sql_ckey = sql_sanitize_text(ckey(key))
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -216,7 +216,7 @@
 		return -1
 		
 /proc/hard_save_player_age(mob/M)
-	if(!M || !M.client || !M.client.prefs))
+	if(!M || !M.client || !M.client.prefs)
 		return 0
 
 	if(config.hard_saving)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -211,10 +211,10 @@
 			return -1
 	else
 		if(config.hard_saving)
-			if(!first_seen)
-				first_seen = full_game_time()
-			if(!last_seen)
-				last_seen = full_game_time()
+			if(!pref.first_seen)
+				pref.first_seen = full_game_time()
+			if(!pref.last_seen)
+				pref.last_seen = full_game_time()
 			
 			return Days_Difference(first_seen , last_seen)
 

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -13,8 +13,8 @@
 	S["ignored_players"]	  << pref.ignored_players
 	S["first_seen"]		  << pref.first_seen
 	S["last_seen"]		  << pref.last_seen
-	S["related_accounts_ip"]  << pref.related_accounts_ip
-	S["related_accounts_cid"] << pref.related_accounts_cid
+	S["ips_associated"]  	  << pref.ips_associated
+	S["cids_associated"]   	  << pref.cids_associated
 /*
 /datum/category_item/player_setup_item/player_global/ooc/sanitize_preferences()
 	if(isnull(pref.ignored_players))
@@ -25,11 +25,11 @@
 	if(!pref.last_seen)
 		pref.last_seen = full_game_time()
 
-	if(isnull(pref.related_accounts_ip))
-		pref.related_accounts_ip = list()
+	if(isnull(pref.cids_associated))
+		pref.cids_associated = list()
 		
-	if(isnull(pref.related_accounts_cid))
-		pref.related_accounts_cid = list()
+	if(isnull(pref.ips_associated))
+		pref.ips_associated = list()
 		
 /datum/category_item/player_setup_item/player_global/ooc/content(var/mob/user)
 	. += "<b>OOC:</b><br>"

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -5,14 +5,14 @@
 /datum/category_item/player_setup_item/player_global/ooc/load_preferences(var/savefile/S)
 	S["ignored_players"]	  >> pref.ignored_players
 	S["first_seen"]		  >> pref.first_seen
-	S["last_seen"]		  >> pref.last_seen
+	S["last_seen"]		 	 >> pref.last_seen
 	S["ips_associated"]  	  >> pref.ips_associated
 	S["cids_associated"]   	  >> pref.cids_associated
 
 /datum/category_item/player_setup_item/player_global/ooc/save_preferences(var/savefile/S)
 	S["ignored_players"]	  << pref.ignored_players
 	S["first_seen"]		  << pref.first_seen
-	S["last_seen"]		  << pref.last_seen
+	S["last_seen"]			  << pref.last_seen
 	S["ips_associated"]  	  << pref.ips_associated
 	S["cids_associated"]   	  << pref.cids_associated
 /*
@@ -21,16 +21,16 @@
 		pref.ignored_players = list()
 
 	if(!pref.first_seen)
-		pref.first_seen = full_game_time()
+		pref.first_seen = full_real_time()
 	if(!pref.last_seen)
-		pref.last_seen = full_game_time()
+		pref.last_seen = full_real_time()
 
 	if(isnull(pref.cids_associated))
 		pref.cids_associated = list()
-		
+
 	if(isnull(pref.ips_associated))
 		pref.ips_associated = list()
-		
+
 /datum/category_item/player_setup_item/player_global/ooc/content(var/mob/user)
 	. += "<b>OOC:</b><br>"
 	. += "Ignored Players<br>"

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -3,17 +3,34 @@
 	sort_order = 4
 
 /datum/category_item/player_setup_item/player_global/ooc/load_preferences(var/savefile/S)
-	S["ignored_players"]	>> pref.ignored_players
-
+	S["ignored_players"]	  >> pref.ignored_players
+	S["first_seen"]		  >> pref.first_seen
+	S["last_seen"]		  >> pref.last_seen
+	S["related_accounts_ip"]  >> pref.related_accounts_ip
+	S["related_accounts_cid"] >> pref.related_accounts_cid
 
 /datum/category_item/player_setup_item/player_global/ooc/save_preferences(var/savefile/S)
-	S["ignored_players"]	<< pref.ignored_players
-
+	S["ignored_players"]	  << pref.ignored_players
+	S["first_seen"]		  << pref.first_seen
+	S["last_seen"]		  << pref.last_seen
+	S["related_accounts_ip"]  << pref.related_accounts_ip
+	S["related_accounts_cid"] << pref.related_accounts_cid
 /*
 /datum/category_item/player_setup_item/player_global/ooc/sanitize_preferences()
 	if(isnull(pref.ignored_players))
 		pref.ignored_players = list()
 
+	if(!pref.first_seen)
+		pref.first_seen = full_game_time()
+	if(!pref.last_seen)
+		pref.last_seen = full_game_time()
+
+	if(isnull(pref.related_accounts_ip))
+		pref.related_accounts_ip = list()
+		
+	if(isnull(pref.related_accounts_cid))
+		pref.related_accounts_cid = list()
+		
 /datum/category_item/player_setup_item/player_global/ooc/content(var/mob/user)
 	. += "<b>OOC:</b><br>"
 	. += "Ignored Players<br>"

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -6,8 +6,8 @@
 	S["ignored_players"]	  >> pref.ignored_players
 	S["first_seen"]		  >> pref.first_seen
 	S["last_seen"]		  >> pref.last_seen
-	S["related_accounts_ip"]  >> pref.related_accounts_ip
-	S["related_accounts_cid"] >> pref.related_accounts_cid
+	S["ips_associated"]  	  >> pref.ips_associated
+	S["cids_associated"]   	  >> pref.cids_associated
 
 /datum/category_item/player_setup_item/player_global/ooc/save_preferences(var/savefile/S)
 	S["ignored_players"]	  << pref.ignored_players

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -16,6 +16,9 @@ datum/preferences
 	var/first_seen
 	var/last_seen
 	
+	var/ips_associated
+	var/cids_associated
+	
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -16,8 +16,8 @@ datum/preferences
 	var/first_seen
 	var/last_seen
 	
-	var/ips_associated
-	var/cids_associated
+	var/list/ips_associated	= list()
+	var/list/cids_associated = list()
 	
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -13,7 +13,9 @@ datum/preferences
 	var/muted = 0
 	var/last_ip
 	var/last_id
-
+	var/first_seen
+	var/last_seen
+	
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color


### PR DESCRIPTION
If the database isn't working/available, let's see if we can still work things out shall we?

* Adds a config option to enable and disable this.
* Adds player join/last seen data to client save files.
* Adds list of related CIDs/IPs to a player's client save.