### PR TITLE
Noticeboard Fix

### DIFF
--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -124,7 +124,7 @@
 	..()
 
 /obj/structure/noticeboard/attack_ai(var/mob/user)
-	examine(user)
+	usr << "<span class = 'notice'>You are too far from \the [src] to examine it.</span>"
 
 /obj/structure/noticeboard/attack_hand(var/mob/user)
 	examine(user)


### PR DESCRIPTION
The AI can no longer interact with noticeboards. Prevents subversive elements from spawning as AI to removing important persistent information during low traffic hours.