### PR TITLE
Alters City Hall Secretary Alt Titles

### DIFF
--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -176,7 +176,7 @@
 	minimum_character_age = 16
 	ideal_character_age = 20 //Really anyone can be this job, not just teens
 
-	alt_titles = list("Junior Clerk", "Assistant Notary", "Paralegal", "City Hall Worker")
+	alt_titles = list("Assistant Clerk", "Notary Public", "Paralegal", "Court Clerk")
 
 	outfit_type = /decl/hierarchy/outfit/job/civilian/secretary
 


### PR DESCRIPTION
Changes Assistant Notary to Notary Public. This is because Notary Public is the proper title for someone that can notarize documents and do nothing else.

Changes City Hall Worker to 'Court Clerk'. The generic title of worker is not helpful, and providing a Court Clerk alt-title provides the Judge with a possible neat little assistant, mirroring the Bailiff alt-title of City Hall Security.

Changes Junior Clerk to Assistant Clerk. There is no 'senior' Clerk, there's just a Clerk and their Assistant Clerks, junior is a silly word for a job title that isn't partner.