### PR TITLE
Adds Accesses for Court Clerk/Bailiff

### DIFF
--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -113,8 +113,8 @@
 	selection_color = "#601C1C"
 	idtype = /obj/item/weapon/card/id/security/prosecutor
 	wage = 100
-	access = list(access_prosecutor, access_sec_doors, access_maint_tunnels, access_heads, access_legal)
-	minimal_access = list(access_prosecutor, access_sec_doors, access_heads, access_legal)
+	access = list(access_prosecutor, access_sec_doors, access_maint_tunnels, access_heads, access_legal, access_warrant)
+	minimal_access = list(access_prosecutor, access_sec_doors, access_heads, access_legal, access_warrant)
 //	minimal_player_age = 7 (need more prostitut-- prosecutors.)
 	minimum_character_age = 21
 	alt_titles = list("Prosecutor","Prosecuting Attorney","Prosecution Officer","Prosecuting Lawyer")
@@ -138,8 +138,8 @@
 	minimal_player_age = 5
 	wage = 90
 	minimum_character_age = 25
-	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors, access_legal)
-	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors, access_legal)
+	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)
+	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)
 
 	outfit_type = /decl/hierarchy/outfit/job/heads/secretary
 	alt_titles = list("Council Bodyguard", "City Hall Security", "Bailiff")

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -138,8 +138,8 @@
 	minimal_player_age = 5
 	wage = 90
 	minimum_character_age = 25
-	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors)
-	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors)
+	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors, access_legal)
+	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_sec_doors, access_legal)
 
 	outfit_type = /decl/hierarchy/outfit/job/heads/secretary
 	alt_titles = list("Council Bodyguard", "City Hall Security", "Bailiff")

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -169,8 +169,8 @@
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/secretary
 	wage = 170
-	access = list(access_heads, access_hop, access_maint_tunnels, access_sec_doors, access_legal)
-	minimal_access = list(access_heads, access_hop, access_maint_tunnels, access_sec_doors, access_legal)
+	access = list(access_heads, access_hop, access_maint_tunnels, access_legal)
+	minimal_access = list(access_heads, access_hop, access_maint_tunnels, access_legal)
 	email_domain = "gov.nt"
 
 	minimum_character_age = 16

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -169,8 +169,8 @@
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/secretary
 	wage = 170
-	access = list(access_heads, access_hop, access_maint_tunnels)
-	minimal_access = list(access_heads, access_hop, access_maint_tunnels)
+	access = list(access_heads, access_hop, access_maint_tunnels, access_sec_doors, access_legal)
+	minimal_access = list(access_heads, access_hop, access_maint_tunnels, access_sec_doors, access_legal)
 	email_domain = "gov.nt"
 
 	minimum_character_age = 16


### PR DESCRIPTION
This adds legal access and sec door access to both City Hall Secretary and legal access to City Hall Security.

The purpose of this is so the City Hall Secretary alt title of Court Clerk can enter the PD's front doors for Court business, and enter the Judge's stand to hand them paperwork and work the desks there.

As well, this will allow the Bailiff to properly bailiff as they will now be able to access the side windoors of the court and the judge's stand without the Judge's help.

