### PR TITLE
Noticeboard QOL

### DIFF
--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -81,7 +81,10 @@
 	dismantle()
 
 /obj/structure/noticeboard/update_icon()
-	icon_state = "[base_icon_state][LAZYLEN(notices)]"
+	if(LAZYLEN(notices) >= 5)
+		icon_state = "[base_icon_state]5"
+	else
+		icon_state = "[base_icon_state][LAZYLEN(notices)]"
 
 /obj/structure/noticeboard/attackby(var/obj/item/weapon/thing, var/mob/user)
 	if(thing.is_screwdriver())

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -7,7 +7,7 @@
 	anchored = 1
 	var/list/notices
 	var/base_icon_state = "nboard0"
-	var/const/max_notices = 5
+	var/const/max_notices = 35
 
 /obj/structure/noticeboard/initialize()
 	. = ..()


### PR DESCRIPTION
A change to noticeboards. Players are making ALOT of noticeboards to keep up with evidence. This PR will increase the amount of papers that can be pinned to 35. 

![image](https://user-images.githubusercontent.com/12586362/74406161-e2c6d400-4dfc-11ea-9f92-13ae2ac8f822.png)
Inspired by **this**.