### PR TITLE
Vending Machine pricing

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -820,7 +820,7 @@
 	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/ice = 10)
 	vending_sound = "machines/vending_coffee.ogg"
 
-	vendor_department = "Bar"
+	vendor_department = "Civilian"
 
 	auto_price = 1
 
@@ -837,7 +837,7 @@
 	contraband = list(/obj/item/weapon/reagent_containers/food/snacks/syndicake = 6,/obj/item/weapon/reagent_containers/food/snacks/unajerky = 6,)
 
 
-	vendor_department = "Bar"
+	vendor_department = "Civilian"
 	auto_price = 1
 
 /obj/machinery/vending/cola
@@ -853,7 +853,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/cans/gingerale = 10, /obj/item/weapon/reagent_containers/food/drinks/bottle/cola = 10)
 	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/cans/thirteenloko = 5, /obj/item/weapon/reagent_containers/food/snacks/liquidfood = 6)
 
-	vendor_department = "Bar"
+	vendor_department = "Civilian"
 	auto_price = 1
 
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -10,6 +10,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 50
 	var/shaken
+	price_tag = 5
 
 /obj/item/weapon/reagent_containers/food/drinks/on_reagent_change()
 	if (reagents.reagent_list.len > 0)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4,6 +4,7 @@
 	desc = "yummy"
 	icon = 'icons/obj/food.dmi'
 	icon_state = null
+	price_tag = 6
 	var/bitesize = 1
 	var/bitecount = 0
 	var/trash = null
@@ -3021,7 +3022,7 @@
 	center_of_mass = list("x"=16, "y"=6)
 	nutriment_desc = list("salt" = 1, "fish" = 1)
 	nutriment_amt = 2
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/caviar/get_item_cost()
 	return 120
 


### PR DESCRIPTION
Per presidential request:

Snacks now cost 5 credits unless otherwise specified by their specific class.
Vending machine drinks now cost 6 credits.

Solves the issue with free vending machine goods.

Coffee, soda, and snack machines now route to the Civilian department account instead of the Bar's account.