### PR TITLE
Allows people to suicide again. (But it will delete your slot)

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -17,66 +17,71 @@
 
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
+	if(!confirm)
+		return
+
 	if(config.canonicity)
-		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
+		var/confirm_canon = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
 		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
 		relating to money, businesses, your political status, and appearance will be lost forever. \
 		This is irreverseable!","Confirm Suicide", "Yes", "No")
 
-	if(confirm == "Yes")
-		if(config.canonicity)
-			handle_delete_character()
-		if(job)
-			job_master.FreeRole(job)
+	if(!confirm_canon)
+		return
 
-		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-			to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
+	if(config.canonicity)
+		handle_delete_character()
+	if(job)
+		job_master.FreeRole(job)
+
+	if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
+		to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
+		return
+	suiciding = 15
+	does_not_breathe = 0			//Prevents ling-suicide zombies, or something
+	var/obj/item/held_item = get_active_hand()
+	if(held_item)
+		var/damagetype = held_item.suicide_act(src)
+		if(damagetype)
+			log_and_message_admins("[key_name(src)] commited suicide using \a [held_item]")
+			var/damage_mod = 1
+			switch(damagetype) //Sorry about the magic numbers.
+							   //brute = 1, burn = 2, tox = 4, oxy = 8
+				if(15) //4 damage types
+					damage_mod = 4
+
+				if(6, 11, 13, 14) //3 damage types
+					damage_mod = 3
+
+				if(3, 5, 7, 9, 10, 12) //2 damage types
+					damage_mod = 2
+
+				if(1, 2, 4, 8) //1 damage type
+					damage_mod = 1
+
+				else //This should not happen, but if it does, everything should still work
+					damage_mod = 1
+
+			//Do 175 damage divided by the number of damage types applied.
+			if(damagetype & BRUTELOSS)
+				adjustBruteLoss(30/damage_mod)	//hack to prevent gibbing
+				adjustOxyLoss(145/damage_mod)
+
+			if(damagetype & FIRELOSS)
+				adjustFireLoss(175/damage_mod)
+
+			if(damagetype & TOXLOSS)
+				adjustToxLoss(175/damage_mod)
+
+			if(damagetype & OXYLOSS)
+				adjustOxyLoss(175/damage_mod)
+
+			//If something went wrong, just do normal oxyloss
+			if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
+				adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+
+			updatehealth()
 			return
-		suiciding = 15
-		does_not_breathe = 0			//Prevents ling-suicide zombies, or something
-		var/obj/item/held_item = get_active_hand()
-		if(held_item)
-			var/damagetype = held_item.suicide_act(src)
-			if(damagetype)
-				log_and_message_admins("[key_name(src)] commited suicide using \a [held_item]")
-				var/damage_mod = 1
-				switch(damagetype) //Sorry about the magic numbers.
-								   //brute = 1, burn = 2, tox = 4, oxy = 8
-					if(15) //4 damage types
-						damage_mod = 4
-
-					if(6, 11, 13, 14) //3 damage types
-						damage_mod = 3
-
-					if(3, 5, 7, 9, 10, 12) //2 damage types
-						damage_mod = 2
-
-					if(1, 2, 4, 8) //1 damage type
-						damage_mod = 1
-
-					else //This should not happen, but if it does, everything should still work
-						damage_mod = 1
-
-				//Do 175 damage divided by the number of damage types applied.
-				if(damagetype & BRUTELOSS)
-					adjustBruteLoss(30/damage_mod)	//hack to prevent gibbing
-					adjustOxyLoss(145/damage_mod)
-
-				if(damagetype & FIRELOSS)
-					adjustFireLoss(175/damage_mod)
-
-				if(damagetype & TOXLOSS)
-					adjustToxLoss(175/damage_mod)
-
-				if(damagetype & OXYLOSS)
-					adjustOxyLoss(175/damage_mod)
-
-				//If something went wrong, just do normal oxyloss
-				if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
-					adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-
-				updatehealth()
-				return
 
 		log_and_message_admins("[key_name(src)] commited suicide")
 		

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -4,25 +4,23 @@
 	set hidden = 1
 
 	if (stat == DEAD)
-		src << "You're already dead!"
+		to_chat(src, "You're already dead!")
 		return
 
 	if (!ticker)
-		src << "You can't commit suicide before the game starts!"
-		return
-
-	if(!player_is_antag(mind))
-		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)
-		src << "No. Adminhelp if there is a legitimate reason."
+		to_chat(src, "You can't commit suicide before the game starts!")
 		return
 
 	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
+		to_chat(src, "You're already committing suicide! Be patient!")
 		return
 
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
+		if(job)
+			job_master.FreeRole(job)
+
 		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
 			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
 			return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -20,8 +20,8 @@
 	if(config.canonicity)
 		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your /
 		character slot, you will never be able to play this character again, ALL of your persistent in-game money /
-		relating to money, businesses, your political status, and appearance will be lost forever. This is irreverseable!",/
-		"Confirm Suicide", "Yes", "No")
+		relating to money, businesses, your political status, and appearance will be lost forever. /
+		This is irreverseable!","Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
 		if(config.canonicity)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -17,7 +17,15 @@
 
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
+	if(config.canonicity)
+		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
+		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
+		relating to money, businesses, your political status, and appearance will be lost forever. This is irreverseable!",\
+		"Confirm Suicide", "Yes", "No")
+
 	if(confirm == "Yes")
+		if(config.canonicity)
+			handle_delete_character()
 		if(job)
 			job_master.FreeRole(job)
 
@@ -164,3 +172,23 @@
 		death(0)
 	else
 		src << "Aborting suicide attempt."
+		
+/mob/living/carbon/human/handle_delete_character()
+	if(!mind ! !mind.prefs)
+		return 0
+		
+	if(!(unique_id == mind.prefs.unique_id))	// make sure it's the same character
+		return 0
+		
+	if(!config.canonicity)
+		return 0
+		
+	if(SSelections && SSelections.current_president)
+		if(SSelections.current_president.unique_id == mind.prefs.unique_id)	// if they're pres, they ded
+			clear_president()
+		for(var/datum/president_candidate/C in political_candidates)	// if they're running, they not any more
+			if(C.unique_id == mind.prefs.unique_id)
+			political_candidates -= C
+
+	mind.prefs.delete_preferences()
+	return 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -19,9 +19,9 @@
 
 	if(!confirm)
 		return
-
+	var/confirm_canon
 	if(config.canonicity)
-		var/confirm_canon = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
+		confirm_canon = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
 		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
 		relating to money, businesses, your political status, and appearance will be lost forever. \
 		This is irreverseable!","Confirm Suicide", "Yes", "No")
@@ -178,7 +178,7 @@
 	else
 		to_chat(src, "Aborting suicide attempt.")
 		
-/mob/living/carbon/human/handle_delete_character()
+/mob/living/carbon/human/proc/handle_delete_character()
 	if(!mind || !mind.prefs)
 		return 0
 		
@@ -193,7 +193,7 @@
 			SSelections.clear_president()
 		for(var/datum/president_candidate/C in SSelections.political_candidates)	// if they're running, they not any more
 			if(C.unique_id == mind.prefs.unique_id)
-			SSelections.political_candidates -= C
+				SSelections.political_candidates -= C
 
 	mind.prefs.delete_character()
 	return 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -18,9 +18,9 @@
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(config.canonicity)
-		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
-		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
-		relating to money, businesses, your political status, and appearance will be lost forever. This is irreverseable!",\
+		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your /
+		character slot, you will never be able to play this character again, ALL of your persistent in-game money /
+		relating to money, businesses, your political status, and appearance will be lost forever. This is irreverseable!",/
 		"Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -185,10 +185,10 @@
 		
 	if(SSelections && SSelections.current_president)
 		if(SSelections.current_president.unique_id == mind.prefs.unique_id)	// if they're pres, they ded
-			clear_president()
-		for(var/datum/president_candidate/C in political_candidates)	// if they're running, they not any more
+			SSelections.clear_president()
+		for(var/datum/president_candidate/C in SSelections.political_candidates)	// if they're running, they not any more
 			if(C.unique_id == mind.prefs.unique_id)
-			political_candidates -= C
+			SSelections.political_candidates -= C
 
-	mind.prefs.delete_preferences()
+	mind.prefs.delete_character()
 	return 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -18,9 +18,9 @@
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(config.canonicity)
-		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your /
-		character slot, you will never be able to play this character again, ALL of your persistent in-game money /
-		relating to money, businesses, your political status, and appearance will be lost forever. /
+		var/confirm = alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
+		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
+		relating to money, businesses, your political status, and appearance will be lost forever. \
 		This is irreverseable!","Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -30,7 +30,7 @@
 			job_master.FreeRole(job)
 
 		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
+			to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
 			return
 		suiciding = 15
 		does_not_breathe = 0			//Prevents ling-suicide zombies, or something
@@ -98,15 +98,15 @@
 	set hidden = 1
 
 	if (stat == 2)
-		src << "You're already dead!"
+		to_chat(src, "You're already dead!")
 		return
 
 	if (!ticker)
-		src << "You can't commit suicide before the game starts!"
+		to_chat(src, "You can't commit suicide before the game starts!")
 		return
 
 	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
+		to_chat(src, "You're already committing suicide! Be patient!")
 		return
 
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
@@ -171,10 +171,10 @@
 			M.show_message("<span class='notice'>[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>", 3, "<span class='notice'>[src] bleeps electronically.</span>", 2)
 		death(0)
 	else
-		src << "Aborting suicide attempt."
+		to_chat(src, "Aborting suicide attempt.")
 		
 /mob/living/carbon/human/handle_delete_character()
-	if(!mind ! !mind.prefs)
+	if(!mind || !mind.prefs)
 		return 0
 		
 	if(!(unique_id == mind.prefs.unique_id))	// make sure it's the same character

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -68,7 +68,7 @@ datum/preferences/proc/set_biological_gender(var/gender)
 	pref.biological_gender  = sanitize_inlist(pref.biological_gender, get_genders(), pick(get_genders()))
 	pref.identifying_gender = (pref.identifying_gender in all_genders_define_list) ? pref.identifying_gender : pref.biological_gender
 	pref.real_name		= sanitize_name(pref.real_name, pref.species, is_FBP())
-	if(!pref.real_name)
+	if(!pref.real_name || (pref.real_name in pref.characters_created))
 		pref.real_name      = random_name(pref.identifying_gender, pref.species)
 
 	if(!pref.birth_year)
@@ -177,6 +177,11 @@ F
 		var/raw_name = input(user, "Choose your character's name:", "Character Name")  as text|null
 		if (!isnull(raw_name) && CanUseTopic(user))
 			var/new_name = sanitize_name(raw_name, pref.species, is_FBP())
+			
+			if(new_name in pref.characters_created)
+				user << "<span class='warning'>You cannot play this character again. Ahelp if this is in error.</span>"
+				return TOPIC_NOACTION
+			
 			if(new_name)
 				pref.real_name = new_name
 				return TOPIC_REFRESH

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -45,6 +45,8 @@ datum/preferences/proc/set_biological_gender(var/gender)
 	S["unique_id"]				<< pref.unique_id
 
 /datum/category_item/player_setup_item/general/basic/delete_character()
+	if(pref.played)
+		pref.characters_created += pref.real_name
 	pref.real_name = null
 	pref.nickname = null
 //	pref.be_random_name = null

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -31,6 +31,8 @@
 	if(isnull(pref.ips_associated) || !islist(pref.ips_associated))
 		pref.ips_associated = list()
 
+	if(isnull(pref.characters_created))
+		pref.characters_created = list()
 /*
 /datum/category_item/player_setup_item/player_global/ooc/content(var/mob/user)
 	. += "<b>OOC:</b><br>"

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -5,17 +5,19 @@
 /datum/category_item/player_setup_item/player_global/ooc/load_preferences(var/savefile/S)
 	S["ignored_players"]	  >> pref.ignored_players
 	S["first_seen"]		  >> pref.first_seen
-	S["last_seen"]		 	 >> pref.last_seen
+	S["last_seen"]		  >> pref.last_seen
 	S["ips_associated"]  	  >> pref.ips_associated
 	S["cids_associated"]   	  >> pref.cids_associated
-
+	S["characters_created"]   >> pref.characters_created
+	
 /datum/category_item/player_setup_item/player_global/ooc/save_preferences(var/savefile/S)
 	S["ignored_players"]	  << pref.ignored_players
 	S["first_seen"]		  << pref.first_seen
-	S["last_seen"]			  << pref.last_seen
+	S["last_seen"]		  << pref.last_seen
 	S["ips_associated"]  	  << pref.ips_associated
 	S["cids_associated"]   	  << pref.cids_associated
-
+	S["characters_created"]   << pref.characters_created
+	
 /datum/category_item/player_setup_item/player_global/ooc/sanitize_preferences()
 	if(isnull(pref.ignored_players))
 		pref.ignored_players = list()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -18,6 +18,7 @@ datum/preferences
 	
 	var/list/ips_associated	= list()
 	var/list/cids_associated = list()
+	var/list/characters_created = list()
 	
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -662,13 +662,6 @@
 /obj/item/weapon/gun/proc/handle_suicide(mob/living/user)
 	if(!ishuman(user))
 		return
-	
-	if(alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
-		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
-		relating to money, businesses, your political status, and appearance will be lost forever. \
-		This is irreverseable!","Confirm Suicide", "Yes", "No") == "No")
-		return
-		
 	var/mob/living/carbon/human/M = user
 
 	mouthshoot = 1
@@ -694,7 +687,6 @@
 		if (in_chamber.damage_type != HALLOSS)
 			log_and_message_admins("[key_name(user)] commited suicide using \a [src]")
 			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, "head", used_weapon = "Point blank shot in the mouth with \a [in_chamber]", sharp=1)
-			M.handle_delete_character()
 			user.death()
 		else
 			user << "<span class = 'notice'>Ow...</span>"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -662,6 +662,13 @@
 /obj/item/weapon/gun/proc/handle_suicide(mob/living/user)
 	if(!ishuman(user))
 		return
+	
+	if(alert("Are you SURE you want to commit suicide? This is a canon round. WARNING: This will delete your \
+		character slot, you will never be able to play this character again, ALL of your persistent in-game money \
+		relating to money, businesses, your political status, and appearance will be lost forever. \
+		This is irreverseable!","Confirm Suicide", "Yes", "No") == "No")
+		return
+		
 	var/mob/living/carbon/human/M = user
 
 	mouthshoot = 1
@@ -687,6 +694,7 @@
 		if (in_chamber.damage_type != HALLOSS)
 			log_and_message_admins("[key_name(user)] commited suicide using \a [src]")
 			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, "head", used_weapon = "Point blank shot in the mouth with \a [in_chamber]", sharp=1)
+			M.handle_delete_character()
 			user.death()
 		else
 			user << "<span class = 'notice'>Ow...</span>"


### PR DESCRIPTION
My friend, you can kill yourself, yes. But at what cost?

Your character slot, all your money and related data will be gone. **Poof.**

Nothing's more annoying than that snowflake who wants to kill themselves over and over and be like "teehee. lemme come back next round", at the same time, perhaps it could have more RP potential. Write yourself a little "goodbye world" note, never come back.

* Makes suicide canon. Only affects canon rounds.
* Does not affect anything but humans that are linked to their loaded slot. (IE: Does not affect other kinds of mobs or non-original bodies, things like brains, cyborgs, NPCs, or if some asshole scientist takes your MMI your put into someone else's synth body and you want out.)
* Presidents and political candidates will instantly be purged from the list.

Going to see if there's any other things we can do this with. 

- [x] Let it warn you when it's doing this, so you are aware of the cost.
- [x] If you are President, the next round will notify of your disappearance/death and run a snap election.
- [x] It will delete your slot. Don't beg admins for it back. Tsk tsk.
- [x] Regardless of your role, it will now free the job slot. So we can relieve the rule of command staff killing themselves.
- [x] Make it apply to objects doing their suicide_act() proc as well. Like guns, but put a warning.
- [x] If your slot is deleted (only IF you've played a round with the character - to avoid bad incidents with redoing a char you're creating), you can't make a character with the same name ever again.