### PR TITLE
Removes Clean Record Requirement for Bodyguard

### DIFF
--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -157,4 +157,3 @@
 	outfit_type = /decl/hierarchy/outfit/job/heads/secretary
 	alt_titles = list("Council Bodyguard", "City Hall Security", "Bailiff")
 
-	clean_record_required = TRUE

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -151,8 +151,8 @@
 	minimal_player_age = 5
 	wage = 90
 	minimum_character_age = 25
-	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)
-	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)
+	access = list(access_heads, access_bodyguard, access_keycard_auth, access_legal)
+	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_legal)
 
 	outfit_type = /decl/hierarchy/outfit/job/heads/secretary
 	alt_titles = list("Council Bodyguard", "City Hall Security", "Bailiff")


### PR DESCRIPTION
No law established a requirement for this and I think it'd be super interesting that since the City Hall Sec Duo is meant to be privately contracted stooges for Council/The Mayor - that they don't actually require a clean criminal record.

You're welcome to disagree with me and close this though.