### PR TITLE
Adds Cannabis Permit Form

### DIFF
--- a/code/modules/paperwork/paperwork_templates/council/cannabispermit.txt
+++ b/code/modules/paperwork/paperwork_templates/council/cannabispermit.txt
@@ -1,0 +1,10 @@
+[center]Geminus City
+Cannabis Permit[/center][small]
+Pursuant to the Civil Code, this Permit is issued by [b]Geminus City[/b] to [b][field][/b], and authorizes:[list][[field]] Cannabis Production (800 Credits)
+[[field]] Cannabis Sales (800 Credits)
+[[field]] Cannabis Consumption (400 Credits)[/list]
+City Official's Signature: [field]
+City Official's Occupation: [field]
+Date: [field]
+[hr]
+[center]STAMP BELOW FOR NOTARIZATION[/center]

--- a/code/modules/paperwork/paperwork_templates/paperwork_defines.dm
+++ b/code/modules/paperwork/paperwork_templates/paperwork_defines.dm
@@ -121,9 +121,15 @@
 
 /datum/paperwork_template/courtrules
 	name = "Courtroom Rules"
-	title = "Courtroom Rulest"
-	categories = list(PAPERWORK_GOVERNMENT)
+	title = "Courtroom Rules"
+	categories = list(PAPERWORK_COUNCIL)
 	file_source = 'code/modules/paperwork/paperwork_templates/council/courtrules.txt'
+
+/datum/paperwork_template/cannabispermit
+	name = "Cannabis Permit"
+	title = "Cannabis Permit"
+	categories = list(PAPERWORK_COUNCIL)
+	file_source = 'code/modules/paperwork/paperwork_templates/council/cannabispermit.txt'
 
 // MEDICAL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a Cannabis Permit Form

## Why It's Good For The Game

Because City Hall can issue cannabis permits but has no way currently to do so.

## Changelog
:cl:
add: Adds a Cannabis Permit form under 'Council' in Load Templates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->