### PR TITLE
Government Official Emails now notify via webhook

### DIFF
--- a/code/__defines/webhooks.dm
+++ b/code/__defines/webhooks.dm
@@ -1,5 +1,5 @@
 // Please don't forget to update the WEBHOOKS section of README.md with your new webhook ID.
 #define WEBHOOK_ROUNDEND          "webhook_roundend"
 #define WEBHOOK_ROUNDSTART        "webhook_roundstart"
-#define WEBHOOK_SUBMAP_LOADED     "webhook_submap_loaded"
 #define WEBHOOK_CUSTOM_EVENT      "webhook_custom_event"
+#define WEBHOOK_EMAIL_GOV 		"webhook_email_gov"

--- a/code/modules/modular_computers/NTNet/emails/email_account.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_account.dm
@@ -65,6 +65,7 @@
 		if(recipient.receive_mail(message, relayed))
 			outbox.Add(message)
 			ntnet_global.add_log_with_ids_check("EMAIL LOG: [login] -> [recipient.login] title: [message.title].")
+
 			return 1
 
 	if(config.canonicity)

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -399,6 +399,14 @@
 			error = "Error sending email: this address doesn't exist or you or the recipient has reached the set message limit."
 			return 1
 		else
+			if(msg_recipient in SSemails.GetGovEmails())
+				SSwebhooks.send(WEBHOOK_EMAIL_GOV, list(
+				"sender" = current_account.login,
+				"reciever" = msg_recipient,
+				"email_title" = msg_title,
+				"email_content" = msg_body
+				))
+
 			error = "Email successfully sent."
 			clear_message()
 			return 1

--- a/code/modules/webhooks/webhook_email_gov.dm
+++ b/code/modules/webhooks/webhook_email_gov.dm
@@ -1,0 +1,15 @@
+
+/decl/webhook/email_gov
+	id = WEBHOOK_EMAIL_GOV
+
+// Data expects a "text" field containing the new custom event text.
+/decl/webhook/email_gov/get_message(var/list/data)
+	. = ..()
+	.["embeds"] = list(list(
+		"title" = "Incoming Email",
+		"sender" = "unknown@invalid.nt",
+		"reciever" = "you@something.nt",
+		"email_title" = "Email Title",
+		"email_content" = (data && data["text"]) || "undefined",
+		"color" = COLOR_WEBHOOK_DEFAULT
+	))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rejoice.

Government emails now send over to the president's quarters in discord. Yahoo!

## Why It's Good For The Game

President can be notified when new emails are sent. Interaction increase.

## Changelog
:cl:
add: President's government email webhook for discord notifications.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->