### PR TITLE
Arrivals Preferences Bugfix

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -15,11 +15,11 @@ datum/preferences
 	var/last_id
 	var/first_seen
 	var/last_seen
-	
+
 	var/list/ips_associated	= list()
 	var/list/cids_associated = list()
 	var/list/characters_created = list()
-	
+
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
@@ -40,7 +40,7 @@ datum/preferences
 	var/birth_year						//year you were born
 	// There's no birth year, as that's automatically calculated by your age.
 
-	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
+	var/spawnpoint = "City Arrivals Airbus" //where this character will spawn (0-2).
 	var/b_type = "O+"					//blood type (not-chooseable)
 	var/backbag = 2					//backpack type
 	var/pdachoice = 1					//PDA type

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -33,6 +33,7 @@ var/list/spawntypes = list()
 	..()
 	turfs = latejoin
 
+/*
 /datum/spawnpoint/gateway
 	display_name = "Gateway"
 	msg = "has completed translation from offsite gateway"
@@ -48,6 +49,7 @@ var/list/spawntypes = list()
 /datum/spawnpoint/elevator/New()
 	..()
 	turfs = latejoin_elevator
+*/
 
 /datum/spawnpoint/cryo
 	display_name = "Cryogenic Storage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gateway and Elevator are no longer selectable spawnpoint in the preferences menu. I have commented it out of the code instead of removing them. Should we ever create a public gateway or a non-sewer elevator, one can un-comment them.

## Why It's Good For The Game

Players will no longer get a warning when they forget to change the spawn point, nor will they select an nonviable spawnpoint.

## Changelog
:cl:
fix: Default arrival point is now "City Arrivals Airbus"
code: Elevator and Gateway commented out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->