### PR TITLE
Adds Persistent Warrants

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -304,3 +304,7 @@ var/global/list/##LIST_NAME = list();\
 #define PAPERWORK_BUSINESS "Business"
 #define PAPERWORK_MEDICAL "Medical"
 #define PAPERWORK_GOVERNMENT "Government"
+
+//
+
+#define MAX_WARRANTS 50

--- a/code/controllers/subsystems/law.dm
+++ b/code/controllers/subsystems/law.dm
@@ -9,9 +9,11 @@ SUBSYSTEM_DEF(law)
 	init_order = INIT_ORDER_LAW
 	flags = SS_NO_FIRE
 	var/list/laws = list()
+	var/list/all_warrants = list()
 
 /datum/controller/subsystem/law/Initialize(timeofday)
 	instantiate_laws()
+	load_warrants()
 
 	return ..()
 
@@ -73,3 +75,47 @@ SUBSYSTEM_DEF(law)
 			K.id = "i[K.prefix]0[x]"
 		else
 			K.id = "i[K.prefix][x]"
+
+
+/datum/controller/subsystem/law/proc/save_warrants()
+	var/list/warrant_list = list()
+
+	for(var/datum/data/record/warrant/W in data_core.warrants)
+		warrant_list += W
+
+	truncate_oldest(warrant_list, MAX_WARRANTS)
+
+	var/path = "data/persistent/law/warrants.sav"
+
+	var/savefile/S = new /savefile(path)
+	if(!fexists(path))
+		return 0
+	if(!S)
+		return 0
+	S.cd = "/"
+
+	S << warrant_list
+
+	return TRUE
+
+/datum/controller/subsystem/law/proc/load_warrants()
+	var/path = "data/persistent/law/warrants.sav"
+
+	var/savefile/S = new /savefile(path)
+	if(!fexists(path))
+		save_warrants()
+		return 0
+	if(!S)
+		return 0
+	S.cd = "/"
+
+	S >> data_core.warrants
+
+	if(!data_core.warrants)
+		data_core.warrants = list()
+
+	all_warrants = data_core.warrants
+
+	truncate_oldest(data_core.warrants, MAX_WARRANTS)
+
+	return TRUE

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -27,9 +27,7 @@ var/activetype = null //Is this a search or arrest warrtant?
 
 //hit yourself with it
 /obj/item/device/holowarrant/attack_self(mob/living/user as mob)
-	sync()
-	if(!storedwarrant.len)
-		to_chat(user, "There seem to be no warrants stored in the device. Please sync with the station's database.")
+	if(!sync(user))
 		return
 	var/temp
 	temp = input(user, "Which warrant would you like to load?") as null|anything in storedwarrant
@@ -39,6 +37,9 @@ var/activetype = null //Is this a search or arrest warrtant?
 			activecharges = W.fields["charges"]
 			activeauth = W.fields ["auth"]
 			activetype = W.fields["arrestsearch"]
+
+	if(temp)
+		to_chat(user, "<span class='notice'>Warrant '[activename]' selected. Use <b>Object > Show Held Item</b> to display the warrant to nearby people.</span>")
 
 //hit other people with it
 /obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
@@ -51,9 +52,11 @@ var/activetype = null //Is this a search or arrest warrtant?
 	if(!isnull(data_core.general))
 		for(var/datum/data/record/warrant/W in data_core.warrants)
 			storedwarrant += W.fields["namewarrant"]
-		to_chat(usr, "<span class='notice'>The device hums faintly as it syncs with the city's warrant database.</span>")
+		to_chat(user, "<span class='notice'>The device hums faintly as it syncs with the city's warrant database.</span>")
+		return 1
 		if(storedwarrant.len == 0)
 			user.visible_message("<span class='notice'>There are no warrants available</span>")
+			return 0
 
 /obj/item/device/holowarrant/proc/show_content(mob/user, forceshow)
 	if(activetype == "arrest")

--- a/code/modules/modular_computers/file_system/programs/police/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/police/digitalwarrant.dm
@@ -84,7 +84,7 @@ var/warrant_uid = 0
 		<small>Person authorizing arrest</small></br>
 		</BODY></HTML>
 		"}
-		
+
 	if(activewarrant.fields["arrestsearch"] == "search")
 		output= {"
 		<HTML><HEAD><TITLE>Search Warrant: [activewarrant.fields["namewarrant"]]</TITLE></HEAD>
@@ -164,6 +164,8 @@ var/warrant_uid = 0
 		. = 1
 		data_core.warrants |= activewarrant
 		activewarrant = null
+
+		truncate_oldest(data_core.warrants, MAX_WARRANTS)
 
 	if(href_list["deletewarrant"])
 		. = 1

--- a/code/modules/persistence/persistent_world.dm
+++ b/code/modules/persistence/persistent_world.dm
@@ -15,6 +15,8 @@
 	//save emails
 	SSemails.save_all_emails()
 
+	SSlaw.save_warrants()
+
 	//save all lots
 //	SSlots.save_all_lots()
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically the title. Warrants will persist through rounds now. It only stores 50 at a time now as a safety procedure - not that you'll need that many warrants.

## Why It's Good For The Game

Extra persistence for the police and legal department is good!

## Changelog
:cl:
add: warrants are now persistent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->