### PR TITLE
Fixes Accidental Suicides

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -17,7 +17,7 @@
 
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
-	if(!confirm)
+	if(confirm == "No")
 		return
 	var/confirm_canon
 	if(config.canonicity)
@@ -26,7 +26,7 @@
 		relating to money, businesses, your political status, and appearance will be lost forever. \
 		This is irreverseable!","Confirm Suicide", "Yes", "No")
 
-	if(!confirm_canon)
+	if(confirm_canon == "No")
 		return
 
 	if(config.canonicity)


### PR DESCRIPTION
Apparently no didn't mean no.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the no dialogue being taken as a yes when committing suicide. 

## Why It's Good For The Game

Fixes people accidentally killing themselves.

## Changelog
:cl:
fix: fixes accidental suicides
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->