### PR TITLE
Removes Buggy News App from Communicators

### DIFF
--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -115,8 +115,7 @@
 	data["aircontents"] = src.analyze_air()
 	data["flashlight"] = fon
 	data["manifest"] = PDA_Manifest
-	data["feeds"] = compile_news()
-	data["latest_news"] = get_recent_news()
+
 	if(cartridge) // If there's a cartridge, we need to grab the information from it
 		data["cart_devices"] = cartridge.get_device_status()
 		data["cart_templates"] = cartridge.ui_templates

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -9,7 +9,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 #define PHONTAB 2
 #define CONTTAB 3
 #define MESSTAB 4
-#define NEWSTAB 5
+// #define NEWSTAB 5
 #define NOTETAB 6
 #define WTHRTAB 7
 #define MANITAB 8
@@ -55,7 +55,6 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 							list("module" = "Phone", "icon" = "phone64", "number" = PHONTAB),
 							list("module" = "Contacts", "icon" = "person64", "number" = CONTTAB),
 							list("module" = "Messaging", "icon" = "comment64", "number" = MESSTAB),
-							list("module" = "News", "icon" = "note64", "number" = NEWSTAB), // Need a different icon,
 							list("module" = "Note", "icon" = "note64", "number" = NOTETAB),
 							list("module" = "Weather", "icon" = "sun64", "number" = WTHRTAB),
 							list("module" = "Crew Manifest", "icon" = "note64", "number" = MANITAB), // Need a different icon,

--- a/nano/templates/communicator.tmpl
+++ b/nano/templates/communicator.tmpl
@@ -191,49 +191,6 @@ Used In File(s): code\game\objects\items\devices\communicator\communicator.dm
 
 <!-- Fifth tab, News -->
 
-{{else data.currentTab == 5}}
-
-	<h3>News</h3>
-	<HR>
-
-	{{if data.feeds.length}}
-		<!--Most recent three posts -->
-		<h4>Recent News</h4>
-		<div class="statusDisplay" style="height: 250px; overflow: auto;">
-		{{for data.latest_news}}
-			<h6>{{:value.channel}}</h6>
-			-{{:value.body}}<br>
-
-			<span class="footer">
-				{{:helper.link('Go to', 'arrow', {'newsfeed' : value.channel})}}
-				[{{:value.message_type}} by <span class="average">{{:value.author}}</span> - {{:value.time_stamp}}]</span>
-			<br>
-		{{empty}}
-		{{/for}}
-		</div>
-		<HR>
-
-		<!--List all newsfeeds -->
-		<h4>News Feeds</h4>
-		<div>
-		{{for data.feeds}}
-			<div class='itemContent'>
-				{{:helper.link(value.name, 'arrow',  {'newsfeed' : value.name})}}
-			</div>
-		{{/for}}
-		</div>
-	{{else}}
-	<!--No news feeds -->
-		<div class="item">
-			<div class="itemLabel">
-				Error
-			</div>
-			<div class="itemContent">
-				No weather reports available. Please try again later.
-			</div>
-		</div>
-	{{/if}}
-
 <!-- Sixth tab, Notekeeper -->
 
 {{else data.currentTab == 6}}


### PR DESCRIPTION
Didn't work and caused sometimes 100s of runtimes per round for anyone who used it. Communicators themselves will be replaced by more robust items, in future.
