### PR TITLE
Byond Age Anti-Grief System

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -44,6 +44,11 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))
 		return 0
+
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You wish to do no harm.</span>")
+		return 0
+
 	if(can_operate(src) && I.do_surgery(src,user))
 		if(I.can_do_surgery(src,user))
 			return 1

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -106,6 +106,14 @@ var/list/gamemode_cache = list()
 	var/guests_allowed = 1
 	var/debugparanoid = 0
 	var/panic_bunker = 0
+
+	var/min_byond_age = 0				//This denies anyone under this byond age from joining.
+
+	var/byond_antigrief_age = 0
+	//A softer option. Clients under this age will be marked with "antigrief" which prevents certain items
+	//from being used such as weapons, explosives, atmos, etc. until they reach a certain age
+
+
 	var/gamemode_vote = 0
 
 	var/serverurl
@@ -734,6 +742,12 @@ var/list/gamemode_cache = list()
 				if("player_levels")
 					using_map.player_levels = text2numlist(value, ";")
 */
+
+				if ("min_byond_age")
+					min_byond_age = text2num(value)
+
+				if ("byond_antigrief_age")
+					byond_antigrief_age = text2num(value)
 
 				if("ssd_protect")
 					config.ssd_protect = text2num(value)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -311,6 +311,12 @@ update_flag
 		onclose(usr, "canister")
 		return
 
+	var/mob/user = usr
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You're not confident enough to mess with this right now.</span>")
+		return 0
+
+
 	if(href_list["toggle"])
 		if (valve_open)
 			if (holding)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -500,7 +500,7 @@
 
 /obj/mecha/attack_hand(mob/user as mob)
 	user.setClickCooldown(user.get_attack_speed())
-	src.log_message("Attack by hand/paw. Attacker - [user].",1)
+	src.log_message("Attack by hand. Attacker - [user].",1)
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
@@ -1066,6 +1066,12 @@
 
 	if (usr.buckled)
 		to_chat(usr,"<span class='warning'>You can't climb into the exosuit while buckled!</span>")
+		return
+
+	var/mob/user = usr
+
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You're not confident using this yet.</span>")
 		return
 
 	src.log_message("[usr] tries to move in.")

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -78,7 +78,13 @@
 		return
 
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
+
+
 	var/flashfail = 0
+
+
+	if(user.IsAntiGrief())
+		flashfail = 1
 
 	if(iscarbon(M))
 		if(!synthetic_only)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -62,6 +62,10 @@
 
 
 /obj/item/weapon/grenade/attack_self(mob/user as mob)
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>How do these things work again?</span>")
+		return 0
+
 	if(!active)
 		if(clown_check(user))
 			user << "<span class='warning'>You prime \the [name]! [det_time/10] seconds!</span>"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -164,6 +164,10 @@
 	if(isrobot(target))
 		return ..()
 
+	if(user.IsAntiGrief())
+		target.visible_message("<span class='warning'>[user] tries to use [src] but fails!</span>")
+		return
+
 	var/agony = agonyforce
 	var/stun = stunforce
 	var/obj/item/organ/external/affecting = null

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -32,12 +32,18 @@
 
 
 /obj/item/device/assembly_holder/attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
+
 	if((!D)||(!D2))	return 0
 	if((!isassembly(D))||(!isassembly(D2)))	return 0
 	if((D:secured)||(D2:secured))	return 0
 	if(user)
 		user.remove_from_mob(D)
 		user.remove_from_mob(D2)
+
 	D:holder = src
 	D2:holder = src
 	D.loc = src
@@ -250,6 +256,12 @@
 	set name = "Set Timer"
 	set category = "Object"
 	set src in usr
+
+	var/mob/user = usr
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
 
 	if ( !(usr.stat || usr.restrained()) )
 		var/obj/item/device/assembly_holder/holder

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -32,6 +32,11 @@
 
 
 /obj/item/device/assembly/igniter/attack_self(mob/user as mob)
+
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
 	activate()
 	add_fingerprint(user)
 	return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -72,10 +72,17 @@ Code:
 /obj/item/device/assembly/signaler/Topic(href, href_list, state = deep_inventory_state)
 	if(..()) return 1
 
+
 	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
 		usr << browse(null, "window=radio")
 		onclose(usr, "radio")
 		return
+
+	var/mob/user = usr
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
 
 	if (href_list["freq"])
 		var/new_frequency = (frequency + text2num(href_list["freq"]))
@@ -90,6 +97,7 @@ Code:
 		src.code = max(1, src.code)
 
 	if(href_list["send"])
+
 		spawn( 0 )
 			signal()
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -86,6 +86,12 @@
 		onclose(usr, "timer")
 		return
 
+	var/mob/user = usr
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
+
 	if(href_list["time"])
 		timing = text2num(href_list["time"])
 		update_icon()

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -48,6 +48,7 @@
 		//things that require the database//
 		////////////////////////////////////
 	var/player_age = "Requires database"	//So admins know why it isn't working - Used to determine how old the account is - in days.
+	var/byond_join_date = null
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
@@ -57,3 +58,4 @@
 
 	// Has the client been granted permission to mess with SSDs by an admin?
 	var/bypass_ssd_guard = FALSE
+	var/antigrief = FALSE		// given to certain clients to prevent grief

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -9,7 +9,8 @@
 	S["ips_associated"]  	  >> pref.ips_associated
 	S["cids_associated"]   	  >> pref.cids_associated
 	S["characters_created"]   >> pref.characters_created
-	
+	S["byond_join_date"]   >> pref.byond_join_date
+
 /datum/category_item/player_setup_item/player_global/ooc/save_preferences(var/savefile/S)
 	S["ignored_players"]	  << pref.ignored_players
 	S["first_seen"]		  << pref.first_seen
@@ -17,7 +18,8 @@
 	S["ips_associated"]  	  << pref.ips_associated
 	S["cids_associated"]   	  << pref.cids_associated
 	S["characters_created"]   << pref.characters_created
-	
+	S["byond_join_date"]   << pref.byond_join_date
+
 /datum/category_item/player_setup_item/player_global/ooc/sanitize_preferences()
 	if(isnull(pref.ignored_players))
 		pref.ignored_players = list()
@@ -35,6 +37,8 @@
 
 	if(isnull(pref.characters_created))
 		pref.characters_created = list()
+
+
 /*
 /datum/category_item/player_setup_item/player_global/ooc/content(var/mob/user)
 	. += "<b>OOC:</b><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -19,6 +19,7 @@ datum/preferences
 	var/list/ips_associated	= list()
 	var/list/cids_associated = list()
 	var/list/characters_created = list()
+	var/byond_join_date
 
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -74,6 +74,10 @@
 		H << "<span class='danger'>You have not selected a grenade type.</span>"
 		return 0
 
+	if(H.IsAntiGrief())
+		to_chat(H, "<span class='danger'>You can't bring yourself to do this.</span>")
+		return 0
+
 	var/datum/rig_charge/charge = charges[charge_selected]
 
 	if(!charge)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -134,6 +134,11 @@
 
 		if(I_HURT)
 
+			if(H.IsAntiGrief())
+				to_chat(H, "<span class='danger'>You wish to do no harm.</span>")
+				return 0
+
+
 			if(M.zone_sel.selecting == "mouth" && wear_mask && istype(wear_mask, /obj/item/weapon/grenade))
 				var/obj/item/weapon/grenade/G = wear_mask
 				if(!G.active)
@@ -146,6 +151,9 @@
 
 			if(!istype(H))
 				attack_generic(H,rand(1,3),"punched")
+				return
+
+			if(H == src) // no more punching yourself to death
 				return
 
 			var/rand_damage = rand(1, 5)
@@ -235,7 +243,7 @@
 				H.visible_message("<span class='danger'>[attack_message]</span>")
 
 			playsound(loc, ((miss_type) ? (miss_type == 1 ? attack.miss_sound : 'sound/weapons/thudswoosh.ogg') : attack.attack_sound), 25, 1, -1)
-			
+
 			add_attack_logs(H,src,"Melee attacked with fists (miss/block)")
 
 			if(miss_type)
@@ -359,6 +367,10 @@
 		return 0
 	var/obj/item/organ/external/organ = get_organ(check_zone(target_zone))
 	if(!organ || organ.dislocated > 0 || organ.dislocated == -1) //don't use is_dislocated() here, that checks parent
+		return 0
+
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>Actually, that might be painful - I'll stop.</span>")
 		return 0
 
 	user.visible_message("<span class='warning'>[user] begins to dislocate [src]'s [organ.joint]!</span>")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -154,6 +154,10 @@
 		if(!S.IsHumanoidToolUser(src))
 			return 0
 
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>Fear sets in and you realise you're too scared to pull the trigger.</span>")
+		return 0
+
 	var/mob/living/M = user
 	if(dna_lock && attached_lock.stored_dna)
 		if(!authorized_user(user))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -217,7 +217,7 @@
 
 			if (href_list["createpill_multiple"])
 				count = input("Select the number of pills to make.", "Max [max_pill_count]", pillamount) as num
-				count = Clamp(count, 1, max_pill_count)
+				count = CLAMP(round(count), 1, max_pill_count) // Fix decimals input and clamp to reasonable amounts
 
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
@@ -229,7 +229,7 @@
 
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
-			while (count--)
+			while(count-- > 0) // Will definitely eventually stop.
 				var/obj/item/weapon/reagent_containers/pill/P = new/obj/item/weapon/reagent_containers/pill(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.name = "[name] pill"

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -29,8 +29,11 @@
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/weapon/reagent_containers/food/drinks/bottle/throw_impact(atom/hit_atom, var/speed)
 	..()
-
 	var/mob/M = thrower
+
+	if(M.IsAntiGrief())
+		return
+
 	if(isGlass && istype(M) && M.a_intent == I_HURT)
 		var/throw_dist = get_dist(throw_source, loc)
 		if(speed >= throw_speed && smash_check(throw_dist)) //not as reliable as smashing directly
@@ -145,6 +148,10 @@
 
 	if(user.a_intent != I_HURT)
 		return
+
+	if(user.IsAntiGrief())
+		return
+
 	if(!smash_check(1))
 		return //won't always break on the first hit
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -34,6 +34,11 @@
 	if (!istype(M))
 		return
 
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You feel you're not qualified to use this.</span>")
+		return
+
+
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -252,6 +252,11 @@
 		overlays += filling
 
 /obj/item/weapon/reagent_containers/syringe/proc/syringestab(mob/living/carbon/target as mob, mob/living/carbon/user as mob)
+
+	if(user && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>You don't want to stab them with a syringe, that would be rude...</span>")
+		return 0
+
 	if(istype(target, /mob/living/carbon/human))
 
 		var/mob/living/carbon/human/H = target

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -127,7 +127,16 @@
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
+
+	if (W.is_hot() && user.IsAntiGrief())
+		to_chat(user, "<span class='danger'>Yikes, that might be a bad idea.</span>")
+		return 0
+
 	if (istype(W,/obj/item/weapon/wrench))
+		if(user.IsAntiGrief())
+			to_chat(user, "<span class='danger'>You don't want to unwrench the faucet...</span>")
+			return 0
+
 		user.visible_message("[user] wrenches [src]'s faucet [modded ? "closed" : "open"].", \
 			"You wrench [src]'s faucet [modded ? "closed" : "open"]")
 		modded = modded ? 0 : 1
@@ -140,6 +149,12 @@
 		if (rig)
 			user << "<span class='warning'>There is another device in the way.</span>"
 			return ..()
+
+
+		if(user && user.IsAntiGrief())
+			to_chat(user, "<span class='danger'>You don't feel like rigging the fueltank.</span>")
+			return 0
+
 		user.visible_message("[user] begins rigging [W] to \the [src].", "You begin rigging [W] to \the [src]")
 		if(do_after(user, 20))
 			user.visible_message("<span class='notice'>[user] rigs [W] to \the [src].</span>", "<span class='notice'>You rig [W] to \the [src]</span>")
@@ -162,6 +177,16 @@
 
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
+	//lot protection
+	var/area/this_area = get_area(src)
+	if(this_area.lot_id)
+		return
+
+	// grief protection
+	var/mob/fueltank_shooter = Proj.firer
+	if(fueltank_shooter.IsAntiGrief() )
+		return
+
 	if(Proj.get_structure_damage())
 		if(istype(Proj.firer))
 			message_admins("[key_name_admin(Proj.firer)] shot fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>).")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -168,9 +168,14 @@
 	var/msg
 	for (var/mob/V in viewers(usr))
 		if(target == user && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-			V.show_message("[usr] starts climbing into the disposal.", 3)
+			V.show_message("[usr] starts climbing into the disposal. It doesn't look like a good idea at all.", 3)
 		if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 			if(target.anchored) return
+
+			if(user.IsAntiGrief())
+				to_chat(user, "<span class='danger'>You realise doing this might be an awful thing to do and stop.</span>")
+				return
+
 			V.show_message("[usr] starts stuffing [target.name] into the disposal.", 3)
 	if(!do_after(usr, 20))
 		return

--- a/code/modules/vehicles/car/car_movement.dm
+++ b/code/modules/vehicles/car/car_movement.dm
@@ -46,6 +46,12 @@
 			A.Move(T)	//bump things away when hit
 
 	if(istype(A, /mob/living))
+		if(istype(buckled_mobs[1], /mob/living/carbon/human))
+			var/mob/D = buckled_mobs[1]
+
+			if(D.IsAntiGrief())
+				return
+
 		var/mob/living/M = A
 		visible_message("<span class='danger'>[src] knocks over [M]!</span>")
 		playsound(src.loc, 'sound/vehicles/car_hit.ogg', 80, 0, 10)
@@ -78,50 +84,18 @@
 				add_attack_logs(D,M,"Ran over [M] with [src] driving as ([D]/[D.ckey]) in [src.loc] (emagged)")
 			healthcheck()
 			return
-	/*
-	//Eh, i'll figure this out. - Cass
-		if(istype(A, /obj/structure))
-			if(emagged)
-				if(istype(A, /obj/structure/barricade))
-					var/obj/structure/barricade/B = A
-					playsound(src.loc, 'sound/effects/woodcrash.ogg', 80, 0, 11025)
-					B.dismantle()
-					return
-				else if(istype(A, /obj/structure/table))
-					var/obj/structure/table/T = A
-					playsound(src.loc, 'sound/effects/woodcrash.ogg', 80, 0, 11025)
-					T.break_to_parts()
-					return
-				else if(istype(A, /obj/structure/grille))
-					var/obj/structure/grille/G = A
-					playsound(src.loc, 'sound/effects/grillehit.ogg', 80, 1)
-					G.health = 0
-					G.healthcheck()
-					return
-				else if(istype(A, /obj/structure/table/rack))
-					var/obj/structure/table/rack/R = A
-					playsound(src.loc, 'sound/effects/grillehit.ogg', 80, 1)
-					R.break_to_parts()
-					return
-				else if(istype(A, /obj/machinery/door/window/))
-					var/obj/machinery/door/window/W = A
-					W.shatter(1)
-					for(var/mob/living/C in buckled_mobs)
-						shake_camera(C, 3, 1)
-					return
-				else if(istype(A, /obj/structure/window/))
-					var/obj/structure/window/W = A
-					W.hit(10)
-					for(var/mob/living/C in buckled_mobs)
-						shake_camera(C, 3, 1)
-					return
-			else
-				return
-	*/
+
 	..()
 
 /obj/vehicle/car/RunOver(var/mob/living/carbon/human/H)
 	..()
+	if(istype(buckled_mobs[1], /mob/living/carbon/human))
+		var/mob/D = buckled_mobs[1]
+
+		if(D.IsAntiGrief())
+			return
+
+
 	visible_message("<span class='danger'>[src] run over [H]!</span>")
 	playsound(src.loc, 'sound/vehicles/car_hit.ogg', 80, 0, 10)
 	var/list/throw_dirs = list(1, 2, 4, 8, 5, 6, 9, 10)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -448,3 +448,10 @@ ALLOW_BUSINESSES
 ## Gamemode voting
 # Comment this out to disable gamemode voting.
 # GAMEMODE_VOTE
+
+## BYOND Age ##
+#Set this to the byond age people need to be to join this server.
+MIN_BYOND_AGE 0
+
+#People under this byond age will be automatically given the anti-grief var
+BYOND_ANTIGRIEF_AGE 14


### PR DESCRIPTION
One thing griefers and ban evaders can't spoof? Their byond account age.

This code adds two settings to the configuration:

Minimum Byond Age:
Prevents people under a certain amount of days (byond registration) from joining the server.

Byond Age AntiGrief:
If you don't want to shut out byond newbies entirely (at least making it something admins can toggle off) a client var called antigrief is added. The person will still be able to join the server and interact but aren't able to do anything that causes massive damage. Such as:

* Shooting guns (any types)
* Using harm intent syringe
* Throwing people down disposals
* Making and activating bombs
* Shooting fueltanks or using welding tools on them.
* Cannot run people over with cars
* Cannot assemble or detonate bombs
* Cannot use flashes or stun batons
* Cannot punch people or use harm intent that will hurt any mobs.
* Cannot use items to bludgeon people with.
* Cannot use grab intent to dislocate limbs.
* Cannot use hypospray.

It won't stop all forms of grief, people can still RP and interact, it just stops the more common types of alt account grief and makes it difficult.

This is intended to be used sparingly to deal with persistent account togglers who keep making new accounts. Since players are rarely brand new to byond playing on our server this should greatly cripple the griefing. If an admin sees a trustable player who is new to byond they can toggle the antigrief var off to allow full game access.