### PR TITLE
More Anti-Grief Methods (Part 3)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -118,6 +118,8 @@ var/list/gamemode_cache = list()
 	var/allow_discord_links = 0
 	var/allow_url_links = 0					// honestly if I were you i'd leave this one off, only use in dire situations
 
+	var/allow_repeat_ooc_messages = 0			 // if set to true, you can't send same message in OOC twice in a row.
+
 	var/gamemode_vote = 0
 
 	var/serverurl

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,7 +97,7 @@ var/list/gamemode_cache = list()
 	var/uneducated_mice = 0 				//Set to 1 to prevent newly-spawned mice from understanding human speech
 
 	var/middle_class_age = 7 			// How many days a player must be before they can make a middle class character
-	var/upper_class_age = 14 				// How many days a player must be before they can make a upper class character
+	var/upper_class_age = 14 			// How many days a player must be before they can make a upper class character
 
 	var/usealienwhitelist = 0
 	var/limitalienplayers = 0
@@ -114,6 +114,9 @@ var/list/gamemode_cache = list()
 	//A softer option. Clients under this age will be marked with "antigrief" which prevents certain items
 	//from being used such as weapons, explosives, atmos, etc. until they reach a certain age
 
+	var/allow_byond_links = 0
+	var/allow_discord_links = 0
+	var/allow_url_links = 0					// honestly if I were you i'd leave this one off, only use in dire situations
 
 	var/gamemode_vote = 0
 
@@ -358,6 +361,9 @@ var/list/gamemode_cache = list()
 
 				if ("debug_paranoid")
 					config.debugparanoid = 1
+
+				if("panic_bunker")
+					config.panic_bunker = 1
 
 				if ("log_admin")
 					config.log_admin = 1
@@ -745,13 +751,25 @@ var/list/gamemode_cache = list()
 */
 
 				if ("min_byond_age")
-					min_byond_age = text2num(value)
+					config.min_byond_age = text2num(value)
 
 				if ("byond_antigrief_age")
-					byond_antigrief_age = text2num(value)
+					config.byond_antigrief_age = text2num(value)
 
 				if ("player_antigrief_age")
-					player_antigrief_age = text2num(value)
+					config.player_antigrief_age = text2num(value)
+
+				if ("allow_byond_links")
+					config.allow_byond_links = 1
+
+				if ("allow_discord_links")
+					config.allow_discord_links = 1
+
+				if ("allow_url_links")
+					config.allow_url_links = 1
+
+				if ("allow_repeat_ooc_messages")
+					config.allow_repeat_ooc_messages = 1
 
 				if("ssd_protect")
 					config.ssd_protect = text2num(value)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -228,6 +228,10 @@
 	if(istype(W, /obj/item/device/floor_painter) && user.a_intent == I_HELP)
 		return // windows are paintable now, so no accidental damage should happen.
 
+	if(user.IsAntiGrief() && (user.a_intent != I_HELP || W))
+		to_chat(user, "<span class='notice'>You don't feel like messing with windows.</span>")
+		return
+
 	// Fixing.
 	if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent == I_HELP)
 		var/obj/item/weapon/weldingtool/WT = W

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -118,6 +118,10 @@
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 
 /turf/simulated/floor/proc/try_deconstruct_tile(obj/item/weapon/W as obj, mob/user as mob)
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='notice'>You don't want to mess with the flooring...</span>")
+		return
+
 	if(istype(W, /obj/item/weapon/crowbar))
 		if(broken || burnt)
 			to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -190,6 +190,9 @@
 
 	//THERMITE related stuff. Calls src.thermitemelt() which handles melting simulated walls and the relevant effects
 	if(thermite)
+		if(user.IsAntiGrief())
+			to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+			return
 		if( istype(W, /obj/item/weapon/weldingtool) )
 			var/obj/item/weapon/weldingtool/WT = W
 			if( WT.remove_fuel(0,user) )
@@ -214,7 +217,6 @@
 	var/turf/T = user.loc	//get user's location for delay checks
 
 	if(damage && istype(W, /obj/item/weapon/weldingtool))
-
 		var/obj/item/weapon/weldingtool/WT = W
 
 		if(!WT.isOn())
@@ -234,7 +236,9 @@
 
 	// Basic dismantling.
 	if(isnull(construction_stage) || !reinf_material)
-
+		if(user.IsAntiGrief())
+			to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+			return
 		var/cut_delay = 60 - material.cut_delay
 		var/dismantle_verb
 		var/dismantle_sound
@@ -281,6 +285,9 @@
 		switch(construction_stage)
 			if(6)
 				if (istype(W, /obj/item/weapon/wirecutters))
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					playsound(src, W.usesound, 100, 1)
 					construction_stage = 5
 					user.update_examine_panel(src)
@@ -289,6 +296,9 @@
 					return
 			if(5)
 				if (istype(W, /obj/item/weapon/screwdriver))
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					to_chat(user, "<span class='notice'>You begin removing the support lines.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,40 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 5)
@@ -311,6 +321,9 @@
 					var/obj/item/weapon/weldingtool/WT = W
 					if(!WT.isOn())
 						return
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					if(WT.remove_fuel(0,user))
 						cut_cover=1
 					else
@@ -319,6 +332,9 @@
 				else if (istype(W, /obj/item/weapon/pickaxe/plasmacutter))
 					cut_cover = 1
 				if(cut_cover)
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					to_chat(user, "<span class='notice'>You begin slicing through the metal cover.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user, 60 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 4)
@@ -340,6 +356,9 @@
 					return
 			if(3)
 				if (istype(W, /obj/item/weapon/crowbar))
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					to_chat(user, "<span class='notice'>You struggle to pry off the cover.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,100 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 3)
@@ -351,6 +370,9 @@
 					return
 			if(2)
 				if (istype(W, /obj/item/weapon/wrench))
+					if(user.IsAntiGrief())
+						to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+						return
 					to_chat(user, "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame.</span>")
 					playsound(src, W.usesound, 100, 1)
 					if(!do_after(user,40 * W.toolspeed) || !istype(src, /turf/simulated/wall) || construction_stage != 2)
@@ -362,6 +384,9 @@
 					return
 			if(1)
 				var/cut_cover
+				if(user.IsAntiGrief())
+					to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+					return
 				if(istype(W, /obj/item/weapon/weldingtool))
 					var/obj/item/weapon/weldingtool/WT = W
 					if( WT.remove_fuel(0,user) )
@@ -382,6 +407,9 @@
 					to_chat(user, "<span class='notice'>The slice through the support rods.</span>")
 					return
 			if(0)
+				if(user.IsAntiGrief())
+					to_chat(user, "<span class='notice'>You don't want to do this.</span>")
+					return
 				if(istype(W, /obj/item/weapon/crowbar))
 					to_chat(user, "<span class='notice'>You struggle to pry off the outer sheath.</span>")
 					playsound(src, W.usesound, 100, 1)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -3,51 +3,14 @@
 	set name = "OOC"
 	set category = "OOC"
 
-	if(say_disabled)	//This is here to try to identify lag problems
-		usr << "<span class='warning'>Speech is currently admin-disabled.</span>"
+	if(!can_speak_ooc(src, msg, "OOC", MUTE_OOC, /datum/client_preference/show_ooc, config.ooc_allowed))
 		return
-
-	if(!mob)	return
-	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
-		return
-
-	msg = sanitize(msg)
-	msg = emoji_parse(msg)
-	if(!msg)	return
-
-	var/raw_msg = msg
-
-
-	if((copytext(msg, 1, 2) in list(".",";","#","say")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
-		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
-			return
-
-	if(!is_preference_enabled(/datum/client_preference/show_ooc))
-		src << "<span class='warning'>You have OOC muted.</span>"
-		return
-
-	if(!holder)
-		if(!config.ooc_allowed)
-			src << "<span class='danger'>OOC is globally muted.</span>"
-			return
-		if(!config.dooc_allowed && (mob.stat == DEAD))
-			usr << "<span class='danger'>OOC for dead mobs has been turned off.</span>"
-			return
-		if(prefs.muted & MUTE_OOC)
-			src << "<span class='danger'>You cannot use OOC (muted).</span>"
-			return
-		if(findtext(msg, "byond://"))
-			src << "<B>Advertising other servers is not allowed.</B>"
-			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
-			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
-			return
 
 	log_ooc(msg, src)
-
+	last_ooc_message = msg
 
 	if(msg)
-		handle_spam_prevention(MUTE_OOC)
+		handle_spam_prevention(MUTE_OOC, sent_message = msg)
 
 	var/ooc_style = "everyone"
 	if(holder && !holder.fakekey)
@@ -73,9 +36,9 @@
 					else
 						display_name = holder.fakekey
 			if(holder && !holder.fakekey && (holder.rights & R_ADMIN) && config.allow_admin_ooccolor && (src.prefs.ooccolor != initial(src.prefs.ooccolor))) // keeping this for the badmins
-				target << "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+				to_chat(target, "<font color='[src.prefs.ooccolor]'><span class='ooc'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
 			else
-				target << "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></span>"
+				to_chat(target, "<span class='ooc'><span class='[ooc_style]'>" + create_text_tag("ooc", "OOC:", target) + " <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></span>")
 
 /client/verb/looc(msg as text)
 	set name = "LOOC"
@@ -83,14 +46,14 @@
 	set category = "OOC"
 
 	if(say_disabled)	//This is here to try to identify lag problems
-		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
+		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 
 	if(!mob)
 		return
 
 	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
+		to_chat(src, "Guests may not use LOOC.")
 		return
 
 	msg = sanitize(msg)
@@ -98,27 +61,12 @@
 	if(!msg)
 		return
 
-	if(!is_preference_enabled(/datum/client_preference/show_looc))
-		src << "<span class='danger'>You have LOOC muted.</span>"
+	if(!can_speak_ooc(src, msg, "LOOC", MUTE_OOC, /datum/client_preference/show_looc, config.looc_allowed))
 		return
 
-	if(!holder)
-		if(!config.looc_allowed)
-			src << "<span class='danger'>LOOC is globally muted.</span>"
-			return
-		if(!config.dooc_allowed && (mob.stat == DEAD))
-			usr << "<span class='danger'>OOC for dead mobs has been turned off.</span>"
-			return
-		if(prefs.muted & MUTE_OOC)
-			src << "<span class='danger'>You cannot use OOC (muted).</span>"
-			return
-		if(findtext(msg, "byond://"))
-			src << "<B>Advertising other servers is not allowed.</B>"
-			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
-			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
-			return
 
 	log_looc(msg,src)
+	last_ooc_message = msg
 
 	if(msg)
 		handle_spam_prevention(MUTE_OOC)
@@ -159,12 +107,12 @@
 		if(target in admins)
 			admin_stuff += "/([key])"
 
-		target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+		to_chat(target, "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>")
 
 	for(var/client/target in r_receivers)
 		var/admin_stuff = "/([key])([admin_jump_link(mob, target.holder)])"
 
-		target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"
+		to_chat(target, "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>")
 
 /mob/proc/get_looc_source()
 	return src
@@ -173,3 +121,67 @@
 	if(eyeobj)
 		return eyeobj
 	return src
+
+/client/proc/can_speak_ooc(client, msg, ooc_type = "OOC", mute_verb = MUTE_OOC, show_preference = /datum/client_preference/show_ooc, toggle_option = config.ooc_allowed)
+
+	if(say_disabled)	//This is here to try to identify lag problems
+		to_chat(src, "<span class='warning'>Speech is currently admin-disabled.</span>")
+		return
+
+
+	if(!mob)	return
+	if(IsGuestKey(key))
+		to_chat(src, "Guests may not use [ooc_type].")
+		return
+
+	msg = sanitize(msg)
+	msg = emoji_parse(msg)
+	if(!msg)	return
+
+	var/raw_msg = msg
+
+
+	if((copytext(msg, 1, 2) in list(".",";","#","say")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
+			return
+
+	if(!is_preference_enabled(show_preference))
+		to_chat(src, "<span class='warning'>You have [ooc_type] muted.</span>")
+		return
+
+	if(!holder)
+		if(!config.ooc_allowed)
+			to_chat(src, "<span class='danger'>[ooc_type] is globally muted.</span>")
+			return
+
+		if(!config.allow_repeat_ooc_messages && (last_ooc_message == msg))
+			to_chat(src, "<span class='danger'>Repeat [ooc_type] messages are disallowed, please edit your message. Last Message: \"[msg]\"</span>")
+			return
+
+		if(!config.dooc_allowed && (mob.stat == DEAD))
+			to_chat(src, "<span class='danger'>[ooc_type] for dead mobs has been turned off.</span>")
+			return
+
+		if(prefs.muted & mute_verb)
+			to_chat(src, "<span class='danger'>You cannot use [ooc_type] (muted).</span>")
+			return
+		if(findtext(msg, "byond://") && !config.allow_byond_links)
+			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
+			log_admin("[key_name(src)] has attempted to advertise in [ooc_type]: [msg]")
+			message_admins("[key_name_admin(src)] has attempted to advertise in [ooc_type]: [msg]")
+			return
+
+		if((findtext(msg, "discord.gg") || findtext(msg, "discord.com/invite")) && !config.allow_discord_links)
+			to_chat(src, "<B>Advertising discords is not allowed.</B>")
+			log_admin("[key_name(src)] has attempted to advertise a discord server in [ooc_type]: [msg]")
+			message_admins("[key_name_admin(src)] has attempted to advertise a discord server in [ooc_type]: [msg]")
+			return
+
+		if((findtext(msg, "http://") || findtext(msg, "https://")) && !config.allow_url_links)
+			to_chat(src, "<B>Posting external links is not allowed.</B>")
+			log_admin("[key_name(src)] has attempted to post a link in [ooc_type]: [msg]")
+			message_admins("[key_name_admin(src)] has attempted to post a link in [ooc_type]: [msg]")
+			return
+
+	return 1
+

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -70,7 +70,8 @@ proc/admin_notice(var/message, var/rights)
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
-		body += "\ <A HREF='?src=\ref[src];togglessdguard=\ref[M]'>Toggle SSD Guard</A> "
+		body += "\ <A HREF='?src=\ref[src];togglessdguard=\ref[M]'>Toggle SSD Guard</A> | "
+		body += "\ <A HREF='?src=\ref[src];toggleantigrief=\ref[M]'>AntiGrief [M.client.antigrief ? "Enabled" : "Disabled"]</A> "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -137,7 +137,7 @@ proc/get_open_ticket_by_client(var/datum/client_lite/owner)
 				var/ref_mob = ""
 				if(owner_client)
 					ref_mob = "\ref[owner_client.mob]"
-				ticket_dat += " - <A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A> - <A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A> - <A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A> - <A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A> - <A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</a>"
+				ticket_dat += " - <A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A> <A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A> <A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A> <A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A> <A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</a> <A HREF='?src=\ref[src];newban=\ref[ref_mob]'>BAN</a>"
 			if(open_ticket && open_ticket == ticket)
 				ticket_dat += "</i>"
 			ticket_dat += "</li>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -825,7 +825,12 @@
 				var/reason = sanitize(input(usr,"Reason?","reason","Griefer") as text|null)
 				if(!reason)
 					return
+
+				if(!M.ckey && M.client && M.client.ckey)	// patch for if they ghost during ban
+					M.ckey = M.client.ckey
+
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
+
 				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
 				notes_add(M.ckey,"[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.",usr)
 				M << "<font color='red'><BIG><B>You have been banned by [usr.client.ckey].\nReason: [reason].</B></BIG></font>"
@@ -1036,6 +1041,21 @@
 
 		log_admin("[key_name(usr)] has [onoff] SSD Guard for [key_name(M)].")
 		message_admins("[key_name_admin(usr)] has [onoff] SSD Guard for [key_name(M)]")
+
+	else if(href_list["toggleantigrief"])
+		var/mob/M = locate(href_list["toggleantigrief"])
+
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!M.client)
+			to_chat(usr, "<span class='warning'>[M] doesn't have an attached client.</span>")
+			return
+
+		M.client.antigrief = !M.client.antigrief
+
+		log_admin("[key_name(usr)] has [M.client.antigrief ? "Enabled" : "Disabled"] SSD Guard for [key_name(M)].")
+		message_admins("[key_name_admin(usr)] has [M.client.antigrief ? "Enabled" : "Disabled"] SSD Guard for [key_name(M)]")
 
 	else if(href_list["tdome1"])
 		if(!check_rights(R_FUN))	return

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -59,3 +59,6 @@
 	// Has the client been granted permission to mess with SSDs by an admin?
 	var/bypass_ssd_guard = FALSE
 	var/antigrief = FALSE		// given to certain clients to prevent grief
+
+	var/last_ooc_message = ""
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -180,7 +180,6 @@
 			antigrief = TRUE
 
 	if(config.min_byond_age)
-		var/player_byond_age = get_byond_age()
 		if(config.min_byond_age > player_byond_age)
 			log_adminwarn("Failed Login: [key] - New account registered on [byond_join_date] (Age: [player_byond_age] days) - Minimum: [config.min_byond_age] days.")
 			message_admins("<span class='adminnotice'>Failed Login: [key] -  New account registered on [byond_join_date] (Age: [player_byond_age] days) - Minimum: [config.min_byond_age] days.</span>")

--- a/code/modules/client/spam_prevention.dm
+++ b/code/modules/client/spam_prevention.dm
@@ -3,7 +3,7 @@
 	var/last_message_time = 0
 	var/spam_alert = 0
 
-/client/proc/handle_spam_prevention(var/mute_type = MUTE_ALL, var/spam_delay = 0.5 SECONDS)
+/client/proc/handle_spam_prevention(var/mute_type = MUTE_ALL, var/spam_delay = 0.5 SECONDS, sent_message)
 	if(world.time - last_message_time < spam_delay)
 		spam_alert++
 		if(spam_alert > 5)
@@ -11,3 +11,5 @@
 	else
 		spam_alert = max(0, spam_alert--)
 	last_message_time = world.time
+	if(sent_message)
+		last_ooc_message = sent_message

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -171,6 +171,9 @@
 		. = TOPIC_HANDLED
 
 	if(href_list["remove"])
+		if(user.IsAntiGrief())
+			to_chat(user, "<span class='notice'>You don't want to remove this paper.</span>")
+			return
 		remove_paper(locate(href_list["remove"]))
 		add_fingerprint(user)
 		. = TOPIC_REFRESH

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -161,6 +161,10 @@ var/list/possible_cable_coil_colours = list(
 		return
 
 	if(istype(W, /obj/item/weapon/wirecutters))
+		if(user.IsAntiGrief())
+			to_chat(user, "<span class='notice'>You feel uneasy with cutting cables, should I do that?</span>")
+			return
+
 		if(d1 == UP || d2 == UP)
 			to_chat(user, "<span class='warning'>You must cut this cable from above.</span>")
 			return

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -73,6 +73,10 @@
 /obj/machinery/chem_master/attack_hand(mob/user as mob)
 	if(stat & BROKEN)
 		return
+	if(user.IsAntiGrief())
+		to_chat(user, "<span class='notice'>You don't feel like messing around with chemistry right now.</span>")
+		return
+
 	user.set_machine(src)
 	ui_interact(user)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -458,3 +458,17 @@ BYOND_ANTIGRIEF_AGE 14
 
 #People under this player age will be automatically given the anti-grief var
 PLAYER_ANTIGRIEF_AGE 5
+
+## Panic Bunker - Comment out to disable the panic bunker.
+# PANIC_BUNKER
+
+## Allow repeat OOC messages in a row - comment out to disable
+ALLOW_REPEAT_OOC_MESSAGES
+
+## OOC/LOOC control ##
+# Uncomment to allow links of the following kinds. #
+
+# ALLOW_BYOND_LINKS
+# ALLOW_DISCORD_LINKS
+ALLOW_URL_LINKS
+


### PR DESCRIPTION
**AntiGrief var mode has been expanded:**
* Disabled ability to destroy windows
* Disabled ability to cut cables or pull up tiles.
* Disabled ability to deconstuct walls or remove plating off them.
* Disabled ability to mix chemicals.
* Disabled ability to remove things from noticeboard.
* Added player panel options to make anti-grief toggleable (easier for admins)

**More config features:**
* Refactored OOC checks a bit
* Made options for disabling byond/discord/url links, all config based

**Other:**
* Added ban button to admin help panel
* Patched issue with ban verb where if someone ghosts it will ban a blank ckey