### PR TITLE
Map + Item Persistence Improvements/Fixes Ghost Walls

### DIFF
--- a/code/controllers/subsystems/initialization/lots.dm
+++ b/code/controllers/subsystems/initialization/lots.dm
@@ -46,6 +46,11 @@ SUBSYSTEM_DEF(lots)
 
 	return 1
 
+/datum/controller/subsystem/lots/proc/refresh_all_lot_turfs()
+	for(var/datum/lot/lots in all_lots)
+		for(var/turf/simulated/wall/T in lots.make_chunk())
+			T.update_icon()
+
 /datum/controller/subsystem/lots/proc/get_lot_by_id(id)
 	for(var/datum/lot/lot in all_lots)
 		if(lot.id == id)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -157,6 +157,7 @@ var/global/datum/controller/gameticker/ticker
 
 	processScheduler.start()
 	Master.SetRunLevel(RUNLEVEL_GAME)
+	SSlots.refresh_all_lot_turfs()
 
 	if(config.sql_enabled)
 		statistic_cycle() // Polls population totals regularly and stores them in an SQL DB -- TLE

--- a/code/modules/persistence/persistent_lots.dm
+++ b/code/modules/persistence/persistent_lots.dm
@@ -169,7 +169,7 @@
 	return e_map
 
 /datum/lot/proc/make_chunk()
-	var/map_turfs = get_map_turfs(top_left, bottom_right)
+	var/list/map_turfs = get_map_turfs(top_left, bottom_right)
 
 	return map_turfs
 


### PR DESCRIPTION
* Lists can now be saved with objects now. Anything that isn't text or a number will still be stripped during sanitization process.
* Ghost walls on lots now fixed, apparently update icon needs to be called for floor to wall changes -after- the game starts.
* Cleans up lot code a tad, makes it a bit faster.
* Walls now load quicker in lots, made an optimisation that all walls start off as their normal base and inherit any subtype attributes that were saved. This is good for keeping consistency but this means some walls in-game will need to be re-painted, sorry.
