### PR TITLE
Adds "Join as Antag" to Lobby Choices

### DIFF
--- a/code/game/antagonist/_antagonist_setup.dm
+++ b/code/game/antagonist/_antagonist_setup.dm
@@ -58,6 +58,16 @@ var/global/list/antag_names_to_ids = list()
 		return antag.current_antagonists
 	return list()
 
+/datum/antagonist/proc/get_all_lobby_antags()
+	var/list/lobby_antags = list()
+	for(var/antag_type in all_antag_types)
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+
+		if(antag.lobby_join)
+			lobby_antags += antag
+
+	return lobby_antags
+
 /proc/player_is_antag(var/datum/mind/player, var/only_offstation_roles = 0)
 	for(var/antag_type in all_antag_types)
 		var/datum/antagonist/antag = all_antag_types[antag_type]
@@ -68,3 +78,4 @@ var/global/list/antag_names_to_ids = list()
 		if(player in antag.pending_antagonists)
 			return 1
 	return 0
+

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -84,6 +84,11 @@
 	var/can_hear_aooc = TRUE		// If FALSE, the antag can neither speak nor hear AOOC. If TRUE, they can at least hear it.
 	var/can_speak_aooc = TRUE		// If TRUE, the antag can freely spean in AOOC.
 
+	var/players_needed = 0			// recommended amount of players required
+	var/police_needed = 0			// recommended amount of police needed
+
+	var/lobby_join = FALSE			// can you join as this type of antagonist from the lobby?
+
 /datum/antagonist/New()
 	..()
 	cur_max = hard_cap


### PR DESCRIPTION
Adds a join as antag button for late join antags. Antags are to be limited to current pop number and police numbers to keep balance.

Hopefully this means we can start having a bit of pizazz but more planning on how to keep this decent is required. Will expand on what antag types and what they have access to later. Putting this here for now.
