### PR TITLE
Adds Antagonist Lobby Join

### DIFF
--- a/code/_global_vars/lists/economy_department.dm
+++ b/code/_global_vars/lists/economy_department.dm
@@ -34,7 +34,6 @@ GLOBAL_LIST_EMPTY(business_ids)
 GLOBAL_LIST_INIT(business_categories, list( // list of categories businesses can list themselves as
 	CAT_ADS,
 	CAT_FARM,
-	CAT_BANK,
 	CAT_LIBRARY,
 	CAT_BUILDING,
 	CAT_EDU,
@@ -42,7 +41,6 @@ GLOBAL_LIST_INIT(business_categories, list( // list of categories businesses can
 	CAT_ENTERTAINMENT,
 	CAT_FOOD,
 	CAT_HOSPITALITY,
-	CAT_LEGAL,
 	CAT_LEISURE,
 	CAT_MANUFACTURE,
 	CAT_MOTOR,
@@ -57,6 +55,12 @@ GLOBAL_LIST_INIT(business_categories, list( // list of categories businesses can
 	CAT_GUNS,
 	CAT_XENOBIO
 ))
+
+GLOBAL_LIST_INIT(license_business_categories, list( // so people stop cheesing this, i'll figure it out another time
+	CAT_BANK,
+	CAT_LEGAL
+))
+
 
 GLOBAL_LIST_INIT(hidden_categories, list( // list of categories businesses cannot list themselves as
 	CAT_DRUGS,

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -793,3 +793,19 @@ SUBSYSTEM_DEF(jobs)
 			var/obj/item/clothing/accessory/permit/synth/permit = new/obj/item/clothing/accessory/permit/synth(get_turf(H))
 			permit.set_name(H.real_name)
 			H.equip_to_slot_or_del(permit, slot_in_backpack)	*/
+
+
+
+/datum/controller/subsystem/jobs/proc/get_active_police()
+
+	var/active_popo = 0
+
+	for(var/J in security_positions)
+		var/datum/job/police_officer = SSjobs.GetJob(J)
+
+		if(!police_officer)
+			continue
+
+		active_popo += police_officer.get_active()
+
+	return active_popo

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -83,6 +83,7 @@ var/list/outfits_decls_by_type_
 		if(istype(O, /obj/item/weapon/card/department))
 			var/obj/item/weapon/card/department/D = O
 			D.owner_name = H.real_name
+			D.update_name()
 
 	if(flags & OUTFIT_HAS_JETPACK)
 		var/obj/item/weapon/tank/jetpack/J = locate(/obj/item/weapon/tank/jetpack) in H

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -5,6 +5,8 @@ var/datum/uplink/uplink = new()
 	var/list/datum/uplink_item/items
 	var/list/datum/uplink_category/categories
 
+
+
 /datum/uplink/New(var/type)
 	items_assoc = list()
 	items = init_subtypes(/datum/uplink_item)
@@ -135,6 +137,9 @@ datum/uplink_item/dd_SortValue()
 
 /datum/uplink_item/item/get_goods(var/obj/item/device/uplink/U, var/loc)
 	var/obj/item/I = new path(loc)
+	if(U && U.block_persistence && isobj(I))
+		I.make_nonpersistent()
+
 	return I
 
 /datum/uplink_item/item/description()

--- a/code/game/antagonist/_antagonist_setup.dm
+++ b/code/game/antagonist/_antagonist_setup.dm
@@ -70,10 +70,3 @@ var/global/list/antag_names_to_ids = list()
 	return 0
 
 
-/proc/get_lobbyjoin_antagonism()
-	var/list/lobbyjoin_antags = list()
-	var/datum/antagonist/antag = all_antag_types
-	if(antag && antag.allow_lobbyjoin)
-		lobbyjoin_antags += antag
-
-	return lobbyjoin_antags

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -101,6 +101,9 @@
 		if(role_text) hud_icon_reference[role_text] = antaghud_indicator
 		if(faction_role_text) hud_icon_reference[faction_role_text] = antaghud_indicator
 
+	if(allow_lobbyjoin)
+		GLOB.lobbyjoin_antagonists += src
+
 
 
 /datum/antagonist/proc/tick()

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -46,3 +46,25 @@
 
 /datum/antagonist/proc/is_latejoin_template()
 	return (flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+
+/datum/antagonist/proc/get_needed_police() // how many police are needed for this antag type?
+	var/playing_antags = get_antag_count()
+	if(!playing_antags)
+		return police_per_antag
+
+	return (police_per_antag * get_antag_count())
+
+/datum/antagonist/proc/meets_police_lobby_join(antags_to_join = 1) // can we get one (or more) for lobby join?
+	if(!get_needed_police())
+		return TRUE
+
+	var/police_needed = get_needed_police() + (antags_to_join * police_per_antag)
+
+	if(police_needed > SSjobs.get_active_police())
+		return FALSE
+
+
+
+GLOBAL_LIST_EMPTY(lobbyjoin_antagonists)
+
+

--- a/code/game/antagonist/station/infiltrator.dm
+++ b/code/game/antagonist/station/infiltrator.dm
@@ -11,8 +11,8 @@ var/datum/antagonist/traitor/infiltrator/infiltrators
 	role_text = "Infiltrator"
 	role_text_plural = "Infiltrators"
 	welcome_text = "To speak on your team's private channel, use :t."
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
-	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 
 	antag_text = "As a infiltrator, you are in a group of other infiltraitors with shared objectives - you are loyal to your objectives and team at all costs. \

--- a/code/game/antagonist/station/infiltrator.dm
+++ b/code/game/antagonist/station/infiltrator.dm
@@ -11,8 +11,13 @@ var/datum/antagonist/traitor/infiltrator/infiltrators
 	role_text = "Infiltrator"
 	role_text_plural = "Infiltrators"
 	welcome_text = "To speak on your team's private channel, use :t."
-	protected_jobs = list("Police Officer", "Prison Warden", "Detective", "Judge", "Chief of Police", "Mayor")
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
+	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+
+	antag_text = "As a infiltrator, you are in a group of other infiltraitors with shared objectives - you are loyal to your objectives and team at all costs. \
+	You are still expected to escalate accordingly <b>with no murderboning</b>. Try to make sure other players have fun! AOOC is enabled, but please do not metagame. \
+	<b>This role has uplink items.</b>"
 
 /datum/antagonist/traitor/infiltrator/New()
 	..()

--- a/code/game/antagonist/station/infiltrator.dm
+++ b/code/game/antagonist/station/infiltrator.dm
@@ -11,7 +11,7 @@ var/datum/antagonist/traitor/infiltrator/infiltrators
 	role_text = "Infiltrator"
 	role_text_plural = "Infiltrators"
 	welcome_text = "To speak on your team's private channel, use :t."
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk", "Chief of Police","Police Officer",\
 	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 

--- a/code/game/antagonist/station/thug.dm
+++ b/code/game/antagonist/station/thug.dm
@@ -5,8 +5,8 @@
 	role_text = "Thug"
 	role_text_plural = "Thugs"
 	bantype = "renegade"
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
-	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	welcome_text = "Sometimes, people just need to get messed up. Luckily, that's what you're here to do."
 	antag_text = "You are a <b>thug</b>! You work with other thugs who work together to do what thugs do, be it violence, drug dealing, theft, or \
 	just extreme self-defense. Try to make sure other players have fun! <b>This role is for crime breaking gang antics not murderboning.</b> \

--- a/code/game/antagonist/station/thug.dm
+++ b/code/game/antagonist/station/thug.dm
@@ -5,7 +5,7 @@
 	role_text = "Thug"
 	role_text_plural = "Thugs"
 	bantype = "renegade"
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk", "Chief of Police","Police Officer",\
 	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	welcome_text = "Sometimes, people just need to get messed up. Luckily, that's what you're here to do."
 	antag_text = "You are a <b>thug</b>! You work with other thugs who work together to do what thugs do, be it violence, drug dealing, theft, or \

--- a/code/game/antagonist/station/thug.dm
+++ b/code/game/antagonist/station/thug.dm
@@ -1,4 +1,3 @@
-var/datum/antagonist/thug/thugs
 
 /datum/antagonist/thug
 	id = MODE_THUG
@@ -6,15 +5,12 @@ var/datum/antagonist/thug/thugs
 	role_text = "Thug"
 	role_text_plural = "Thugs"
 	bantype = "renegade"
-	restricted_jobs = list("AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
 	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
-	welcome_text = "Sometimes, people just need to get messed up.Luckily, that's what you're here to do."
-	antag_text = "You are a <b>thug</b>! Within the server rules, do whatever it is \
-		that you came to the city to do, be it violence, drug dealing, theft, or \
-		just extreme self-defense. Try to make sure other players have <i>fun</i>! \
-		This role is for <b>crime breaking gang antics not murderboning.</b><br> \
-		<br>This is a <b>teamwork role</b>, roleplay with your fellow gang members \
-		and brainstorm what you will do. <b>AOOC</b> may be used."
+	welcome_text = "Sometimes, people just need to get messed up. Luckily, that's what you're here to do."
+	antag_text = "You are a <b>thug</b>! You work with other thugs who work together to do what thugs do, be it violence, drug dealing, theft, or \
+	just extreme self-defense. Try to make sure other players have fun! <b>This role is for crime breaking gang antics not murderboning.</b> \
+	This is a <b>teamwork role</b>, roleplay with your fellow gang members and brainstorm what you will do. AOOC may be used."
 	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	can_speak_aooc = TRUE
 	can_hear_aooc = TRUE
@@ -22,7 +18,7 @@ var/datum/antagonist/thug/thugs
 	antag_indicator = "thug"
 	initial_spawn_req = 2
 	initial_spawn_target = 4
-
+	hard_cap = 8
 	//Thugs get their own universal outfit, each round.
 	var/gang_gimmick = "biker_gang"
 	var/nick
@@ -37,6 +33,8 @@ var/datum/antagonist/thug/thugs
 
 	allow_lobbyjoin = TRUE
 
+	var/list/all_thugs = list()
+
 /datum/antagonist/thug/New()
 	..()
 	pick_outfit()
@@ -45,12 +43,9 @@ var/datum/antagonist/thug/thugs
 	var/msg
 
 	msg += "<b>Your gang:</b><br>"
-	for (var/mob/living/carbon/human/C in mob_list)
+	for (var/mob/living/carbon/human/C in all_thugs)
 		if(C.mind.special_role == "Thug")
-			msg += "[nick] <b>[C.name]</b>, the [C.job]. <br>"
-
-	gang_mob << "[msg]"
-
+			to_chat(gang_mob, "[nick] <b>[C.name]</b>, the [C.job].")
 
 /datum/antagonist/thug/proc/pick_outfit()
 	//Picks a random outfit each round, so thugs have their identity.
@@ -93,6 +88,10 @@ var/datum/antagonist/thug/thugs
 	if(!..())
 		return
 
+	all_thugs += player
+
+	get_gang(player)
+
 	to_chat(player, "<span class='danger'>You remember that you brought your uniform and weapons in a box with you - as discussed from a meeting with your gang...</span>")
 
 	var/obj/item/weapon/storage/box/kit = new(get_turf(player))
@@ -122,3 +121,10 @@ var/datum/antagonist/thug/thugs
 
 
 
+/datum/antagonist/thug/unequip(var/mob/living/carbon/human/player)
+	if(!istype(player))
+		return 0
+
+	all_thugs -= player
+
+	return 1

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -5,8 +5,8 @@ var/datum/antagonist/traitor/traitors
 	id = MODE_TRAITOR
 	protected_jobs = list("Prisoner", "Police Officer", "Prison Warden", "Detective", "Judge", "Chief of Police", "Mayor")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
-	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	can_speak_aooc = TRUE
 	antag_text = "As a traitor, you are a solo operative who works on behalf of local syndicate contractors to perform certain roles. \
 	You are still expected to escalate accordingly. Try to make sure other players have fun! AOOC is enabled, but please do not metagame. \

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,10 +3,14 @@ var/datum/antagonist/traitor/traitors
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
-	protected_jobs = list("Police Officer", "Prison Warden", "Detective", "Judge", "Chief of Police", "Mayor")
+	protected_jobs = list("Prisoner", "Police Officer", "Prison Warden", "Detective", "Judge", "Chief of Police", "Mayor")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","Chief of Police","Police Officer",\
+	"Prison Warden","Detective","Chief Medical Officer","Chief Engineer","Research Director","Judge")
 	can_speak_aooc = TRUE
-
+	antag_text = "As a traitor, you are a solo operative who works on behalf of local syndicate contractors to perform certain roles. \
+	You are still expected to escalate accordingly. Try to make sure other players have fun! AOOC is enabled, but please do not metagame. \
+	<b>This role has uplink items.</b>"
 	allow_lobbyjoin = TRUE
 	police_per_antag = 2
 
@@ -15,6 +19,7 @@ var/datum/antagonist/traitor/traitors
 	allow_latejoin = 1
 	hard_cap = 4
 	initial_spawn_target = 4
+	allow_lobbyjoin = FALSE
 
 /datum/antagonist/traitor/New()
 	..()

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -5,7 +5,7 @@ var/datum/antagonist/traitor/traitors
 	id = MODE_TRAITOR
 	protected_jobs = list("Prisoner", "Police Officer", "Prison Warden", "Detective", "Judge", "Chief of Police", "Mayor")
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk""Chief of Police","Police Officer",\
+	restricted_jobs = list("Prisoner", "AI", "Cyborg","Mayor","City Clerk", "Chief of Police","Police Officer",\
 	"Prison Warden","Detective","Medical Director","Maintenance Director","Research Director","Judge")
 	can_speak_aooc = TRUE
 	antag_text = "As a traitor, you are a solo operative who works on behalf of local syndicate contractors to perform certain roles. \

--- a/code/game/gamemodes/thug/thug.dm
+++ b/code/game/gamemodes/thug/thug.dm
@@ -10,11 +10,3 @@
 	required_players_secret = 5
 	required_enemies = 3
 	end_on_antag_death = 0
-
-
-/datum/game_mode/thug/post_setup()
-	for (var/mob/living/carbon/human/C in mob_list)
-		if(C.mind.special_role == "Thug")
-			for(var/datum/antagonist/thug/W)
-				W.get_gang(C)
-	..()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -220,3 +220,4 @@
 			active++
 
 	return active
+

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -93,7 +93,7 @@ var/list/engineering_positions = list(
 
 var/list/medical_positions = list(
 	"Medical Director",
-	"Physician",
+	"Doctor",
 	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
@@ -108,8 +108,7 @@ var/list/science_positions = list(
 	"Geneticist",	//Part of both medical and science
 	"Roboticist",
 	"Xenobiologist",
-	"Research Assistant",
-	"Research Security"
+	"Research Assistant"
 )
 
 //BS12 EDIT
@@ -122,16 +121,11 @@ var/list/cargo_positions = list(
 var/list/civilian_positions = list(
 	"City Clerk",
 	"Judge",
-	"Bartender",
-	"Botanist",
-	"Chef",
-	"Journalist",
 	"Defense Attorney",
 	"Chaplain",
 	"Civilian",
-	"Barber",
+	"City Hall Guard",
 	"City Hall Secretary",
-	"Bar Manager"
 )
 
 
@@ -140,7 +134,6 @@ var/list/security_positions = list(
 	"Prison Warden",
 	"Detective",
 	"Police Officer",
-	"City Hall Guard",
 	"District Prosecutor"
 )
 

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -15,7 +15,7 @@
 	var/next_offer_time					//The time a discount will next be offered
 	var/datum/uplink_item/discount_item	//The item to be discounted
 	var/discount_amount					//The amount as a percent the item will be discounted by
-
+	var/block_persistence = TRUE
 /obj/item/device/uplink/nano_host()
 	return loc
 

--- a/code/modules/economy/department_cards.dm
+++ b/code/modules/economy/department_cards.dm
@@ -24,10 +24,10 @@
 
 /obj/item/weapon/card/department/New()
 	..()
-	update_icon()
+
 	var/datum/department/D = get_department()
-	if(D.dept_type != HIDDEN_DEPARTMENT)
-		name = "[D.name] [initial(name)]"
+	update_icon()
+	update_name()
 
 	spending_limit = D.card_spending_limit
 
@@ -47,6 +47,17 @@
 		var/image/I =  image(icon, "[initial(icon_state)]_overlay")
 		I.color = D.dept_color
 		overlays |= I
+
+/obj/item/weapon/card/department/proc/update_name()
+	var/datum/department/D = get_department()
+
+	if(owner_name)
+		name = "[owner_name]'s [D.name] [initial(name)]"
+
+	if(D.dept_type != HIDDEN_DEPARTMENT)
+		name = "[D.name] [initial(name)]"
+
+
 
 /obj/item/weapon/card/department/proc/can_spend(num, type)
 	// returns null if there's no department or department bank account. returns -1 if dept suspended. returns -2 if wrong type.

--- a/code/modules/government/business/business.dm
+++ b/code/modules/government/business/business.dm
@@ -71,7 +71,7 @@
 		categories += CAT_RETAIL
 
 	for(var/V in categories) // remove anything that's not meant to be there
-		if(!(V in GLOB.business_categories))
+		if(!(V in GLOB.business_categories+GLOB.license_business_categories))
 			categories -= V
 
 	refresh_business_support_list()

--- a/code/modules/mob/new_player/JoinAsAntag.dm
+++ b/code/modules/mob/new_player/JoinAsAntag.dm
@@ -6,7 +6,7 @@
 	var/dat = JoinAntagData()
 
 
-	var/datum/browser/popup = new(usr, "joinasantag", "Join As Antag", 350, 430, src)
+	var/datum/browser/popup = new(usr, "joinasantag", "Join As Antag", 470, 730, src)
 	popup.set_content(jointext(dat,null))
 	popup.open()
 
@@ -21,15 +21,93 @@
 		dat += "<center><font color='red'>Joining as an antagonist is currently disabled.</font></center><br>"
 		return dat
 
+	var/datum/job/job = SSjobs.GetJob(selected_job)
 
-	var/list/lobby_antagonists = get_lobbyjoin_antagonism()
+	if(!job)
+		job = SSjobs.GetJob("Civilian")
+
+	dat += "<b>Current Character:</b> [client.prefs.real_name]<br>"
+	dat += "<b>Current Job:</b> [job.title]<br>"
+	dat += "<b>Active Police Officers:</b> [SSjobs.get_active_police()]<hr>"
+
+	if(config.canonicity)
+		dat += "<b>NOTICE:</b> This is a <i>canon</i> round, everything your character does this round is canon. Your character's criminal record and \
+		reputation is persistent and will be remembered if you are found out - it cannot be retconned. If this is a character you would prefer <i>not</i> \
+		to be remembered for traitorous infamy, use another character.<br>"
+	else
+		dat += "The current round is not persistent, actions you do will not be remembered or saved next round.<br>"
+
+	var/list/lobby_antagonists = GLOB.lobbyjoin_antagonists
 
 
 	if(!LAZYLEN(lobby_antagonists))
 		dat += "There are no antagonist types available for joining at the moment, please visit later."
 	else
+		dat += "<br>"
+
 		for(var/datum/antagonist/antag in lobby_antagonists)
-			dat += "<a href=''>[antag.role_text]</a><br>"
+
+			dat += "<fieldset style='width: 80%; border: 2px solid red; display: inline'>"
+			dat += "<legend align='left' style='color: #fff'>[antag.role_text]</legend>"
+
+			dat += "<br>[antag.antag_text]"
+			if(config.use_age_restriction_for_antags)
+				dat += "<br><b>Minimum Player Age:</b> [antag.minimum_player_age] (Current: [client.player_age])"
+
+			dat += "<br><b>Max [antag.role_text_plural]:</b> "
+			if(antag.hard_cap)
+				dat += "[antag.get_antag_count()]/[antag.hard_cap]"
+			else
+				dat += "Unlimited"
+			if(antag.police_per_antag)
+				dat += "<br><b>Police Per [antag.role_text]:</b> [antag.police_per_antag]"
+
+			if(job.title in antag.restricted_jobs)
+				dat += "<br><font color='red'><b>This antagonist type cannot be played by your current job: [job.title].</b></font>"
+
+			if(!antag.can_become_antag(mind))
+				dat += "<br><font color='red'><b>You are not eligible for this role.</b></font>"
+
+			else if(antag.get_antag_count() >= antag.hard_cap)
+				dat += "<br><font color='red'><b>This antag type has reached the maximum amount.</b></font>"
+
+			else if(!antag.meets_police_lobby_join())
+				dat += "<br><font color='red'><b>To join, the round needs at least [antag.get_needed_police()] police officer(s).</b></font>"
+			else
+				dat += "<br><a href='byond://?src=\ref[src];JoinAsAntag=[antag.id]'>Join As [antag.role_text]</a>"
+
+			dat += "</fieldset>"
+
+			dat += "<br>"
 
 
 	return dat
+
+
+/mob/new_player/proc/JoinAntag(var/datum/antagonist/antag)
+
+	if(!antag || !istype(antag, /datum/antagonist) )
+		return FALSE
+
+	if(selected_job in antag.restricted_jobs)
+		to_chat(src, "<b>This antagonist type cannot be played by your current job: [selected_job].</b></font>")
+		return FALSE
+
+	if(antag.get_antag_count() >= antag.hard_cap)
+		to_chat(src, "This antag type has reached the max count.")
+		return FALSE
+
+	if(!antag.can_become_antag(mind))
+		to_chat(src, "You are not eligible for this antagonist type.")
+		return FALSE
+
+	if(antag.get_antag_count() >= antag.hard_cap)
+		to_chat(src, "Limit for this antagonist group reached.")
+		return FALSE
+
+	if(!antag.meets_police_lobby_join())
+		to_chat(src, "This antagonist type cannot be joined until more police officers join.")
+		return FALSE
+
+
+	JoinLate(selected_job, antag.id)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -116,6 +116,35 @@
 				totalPlayers++
 				if(player.ready)totalPlayersReady++
 
+
+/mob/new_player/proc/JoinLate(selected_job_name, antag_type)
+	//Prevents people rejoining as same character.
+	for (var/mob/living/carbon/human/C in mob_list)
+		var/char_name = client.prefs.real_name
+		if(char_name == C.real_name)
+			to_chat(usr, "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>")
+			return
+
+	if(!config.enter_allowed)
+		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
+		return
+	else if(ticker && ticker.mode && ticker.mode.explosion_in_progress)
+		to_chat(usr, "<span class='danger'>The city is currently exploding. Joining would go poorly.</span>")
+		return
+
+	if(!is_alien_whitelisted(src, all_species[client.prefs.species]))
+		src << alert("You are currently not whitelisted to play [client.prefs.species].")
+		return 0
+
+	var/datum/species/S = all_species[client.prefs.species]
+	if(!(S.spawn_flags & SPECIES_CAN_JOIN))
+		src << alert("Your current species, [client.prefs.species], is not available for play on the city.")
+		return 0
+
+	AttemptLateSpawn(selected_job_name,client.prefs.spawnpoint, antag_type)
+
+	return TRUE
+
 /mob/new_player/Topic(href, href_list[])
 	if(!client)	return 0
 
@@ -178,13 +207,36 @@
 
 		LateChoices()
 
-
 	if(href_list["join_as_antag"])
+
 		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
 			to_chat(usr,"<font color='red'>The round is either not ready, or has already finished...</font>")
 			return
 
 		JoinAsAntag()
+
+	if(href_list["JoinAsAntag"])	//pre- SelectedJob usage for new menu
+		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
+			to_chat(usr,"<font color='red'>The round is either not ready, or has already finished...</font>")
+			return
+
+		var/E = href_list["JoinAsAntag"]
+
+		var/antag_type = E
+		var/datum/antagonist/antag = null
+
+		for(var/datum/antagonist/A in GLOB.lobbyjoin_antagonists)
+			if(A.id == antag_type)
+				antag = A
+
+		if(!antag)
+			return
+
+		JoinAntag(antag)
+
+		return
+
+
 
 	if(href_list["manifest"])
 		ViewManifest()
@@ -228,31 +280,8 @@
 		return
 
 	if(href_list["SelectedJob"])
-		//Prevents people rejoining as same character.
-		for (var/mob/living/carbon/human/C in mob_list)
-			var/char_name = client.prefs.real_name
-			if(char_name == C.real_name)
-				to_chat(usr, "<span class='notice'>There is a character that already exists with the same name - <b>[C.real_name]</b>, please join with a different one.</span>")
-				return
+		JoinLate(href_list["SelectedJob"])
 
-		if(!config.enter_allowed)
-			to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
-			return
-		else if(ticker && ticker.mode && ticker.mode.explosion_in_progress)
-			to_chat(usr, "<span class='danger'>The city is currently exploding. Joining would go poorly.</span>")
-			return
-
-		if(!is_alien_whitelisted(src, all_species[client.prefs.species]))
-			src << alert("You are currently not whitelisted to play [client.prefs.species].")
-			return 0
-
-		var/datum/species/S = all_species[client.prefs.species]
-		if(!(S.spawn_flags & SPECIES_CAN_JOIN))
-			src << alert("Your current species, [client.prefs.species], is not available for play on the city.")
-			return 0
-
-		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
-		return
 
 	if(href_list["privacy_poll"])
 		establish_db_connection()
@@ -395,7 +424,7 @@
 
 	return 1
 
-/mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
+/mob/new_player/proc/AttemptLateSpawn(rank, var/spawning_at, antag_type)
 	if (src != usr)
 		return 0
 	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
@@ -484,6 +513,11 @@
 	else
 		AnnounceCyborg(character, rank, join_message)
 
+
+	//assign antag role, if any
+	var/datum/antagonist/antag = all_antag_types[antag_type]
+	if(antag)
+		antag.add_antagonist(character.mind,1,0,1)
 
 
 	qdel(src)
@@ -581,6 +615,7 @@
 
 	src << browse(null, "window=latechoices") //closes late choices window
 	src << browse(null, "window=News") //closes news window
+	src << browse(null, "window=joinasantag") //closes news window
 	//src << browse(null, "window=playersetup") //closes the player setup window
 	panel.close()
 

--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -41,6 +41,20 @@
 /atom/proc/on_persistence_save()
 	persistence_loaded = TRUE
 
+/atom/proc/make_persistent()
+	dont_save = FALSE
+
+	for(var/V in get_saveable_contents())
+		dont_save = FALSE
+
+/atom/proc/make_nonpersistent()
+	dont_save = TRUE
+
+	for(var/V in get_saveable_contents())
+		dont_save = TRUE
+
+
+
 /atom/proc/get_persistent_metadata()
 	return
 


### PR DESCRIPTION
* Allows players to join during canon rounds as an antag. Thugs, traitors and infiltrators only for now.
* Uplink traitor items (including box contents) are non-persistent if spawned through traitor uplink to prevent economic fuckery.
* Antags are ratio'ed by the number of police online.
* A notice is added to warn players that joining a canon round on antag has permanent consequences to prevent BAAAAAAAW.
* BAAAAAAAW.

**Demo:**
![image](https://user-images.githubusercontent.com/12565163/89717593-f1f39c80-d9af-11ea-8732-9561684b09a3.png)
