### PR TITLE
Antag Mode Fixes

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -54,17 +54,21 @@
 
 	return (police_per_antag * get_antag_count())
 
-/datum/antagonist/proc/meets_police_lobby_join(antags_to_join = 1) // can we get one (or more) for lobby join?
+/datum/antagonist/proc/meets_police_lobby_join() // can we get one (or more) for lobby join?
 	if(!get_needed_police())
 		return TRUE
 
-	if(!LAZYLEN(get_antag_count()))
-		return TRUE
-
-	var/police_needed = get_needed_police() + (antags_to_join * police_per_antag)
+	var/police_needed = get_needed_police() + police_per_antag
 
 	if(SSjobs.get_active_police() >= police_needed)
 		return TRUE
+
+/proc/get_lobbyjoin_antag_count()
+	var/count = 0
+	for(var/datum/antagonist/antag in lobbyjoin_antagonists)
+		count += antag.get_antag_count()
+
+	return count
 
 
 

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -65,7 +65,7 @@
 
 /proc/get_lobbyjoin_antag_count()
 	var/count = 0
-	for(var/datum/antagonist/antag in lobbyjoin_antagonists)
+	for(var/datum/antagonist/antag in GLOB.lobbyjoin_antagonists)
 		count += antag.get_antag_count()
 
 	return count

--- a/code/game/gamemodes/canon/canon.dm
+++ b/code/game/gamemodes/canon/canon.dm
@@ -9,3 +9,13 @@
 	votable = TRUE
 
 	allow_late_antag = TRUE
+	show_antag_print = TRUE // antags can be late added
+
+
+/datum/game_mode/canon/noncanon
+	name = "Non-Canon"
+	config_tag = "noncanon"
+	canon = FALSE
+	round_description = "We're all in a TV show, nothing is real. Nothing saves."
+	extended_round_description = "This round is NOT canon, your character and money won't save and nothing in this round applies. \
+	Conflict is allowed if it is well roleplayed and flows well into the story, a bit more chaos is allowed than usual. Lot vandalism rules do not apply."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -42,6 +42,9 @@ var/global/list/additional_antag_types = list()
 
 	var/allow_late_antag = FALSE
 
+	var/show_antag_print = FALSE			// show antag print at round end?
+	var/max_antags = 8					// maximum cap for antags in a round for lobby latejoin. Note: Still limited by how many police are online.
+
 /datum/game_mode/New()
 	..()
 
@@ -243,7 +246,6 @@ var/global/list/additional_antag_types = list()
 		"hostile raiders",
 		"derelict station debris",
 		"REDACTED",
-		"ancient alien artillery",
 		"solar magnetic storms",
 		"sentient time-travelling killbots",
 		"gravitational anomalies",
@@ -258,8 +260,7 @@ var/global/list/additional_antag_types = list()
 		"malfunctioning von Neumann probe swarms",
 		"shadowy interlopers",
 		"a stranded alien arkship",
-		"haywire IPC constructs",
-		"rogue Unathi exiles",
+		"deviant synthetics",
 		"artifacts of eldritch horror",
 		"a brain slug infestation",
 		"killer bugs that lay eggs in the husks of the living",
@@ -290,7 +291,7 @@ var/global/list/additional_antag_types = list()
 /datum/game_mode/proc/declare_completion()
 	var/is_antag_mode = (antag_templates && antag_templates.len)
 	check_victory()
-	if(is_antag_mode)
+	if(show_antag_print || is_antag_mode)
 		sleep(10)
 		for(var/datum/antagonist/antag in antag_templates)
 			sleep(10)

--- a/code/modules/mob/new_player/JoinAsAntag.dm
+++ b/code/modules/mob/new_player/JoinAsAntag.dm
@@ -29,6 +29,7 @@
 	dat += "<b>Current Character:</b> [client.prefs.real_name]<br>"
 	dat += "<b>Current Job:</b> [job.title]<br>"
 	dat += "<b>Active Police Officers:</b> [SSjobs.get_active_police()]<hr>"
+	dat += "<b>Antag Cap:</b> [get_lobbyjoin_antag_count()]/[ticker.mode.max_antags]<br>"
 
 	if(config.canonicity)
 		dat += "<b>NOTICE:</b> This is a <i>canon</i> round, everything your character does this round is canon. Your character's criminal record and \
@@ -65,13 +66,16 @@
 			if(job.title in antag.restricted_jobs)
 				dat += "<br><font color='red'><b>This antagonist type cannot be played by your current job: [job.title].</b></font>"
 
-			if(!antag.can_become_antag(mind))
+			else if(!antag.can_become_antag(mind))
 				dat += "<br><font color='red'><b>You are not eligible for this role.</b></font>"
+
+			else if(get_lobbyjoin_antag_count() >= ticker.mode.max_antags)
+				dat += "<b>Max antag count for this gamemode reached.</b></font>"
 
 			else if(antag.get_antag_count() >= antag.hard_cap)
 				dat += "<br><font color='red'><b>This antag type has reached the maximum amount.</b></font>"
 
-			else if(!antag.meets_police_lobby_join(1))
+			else if(!antag.meets_police_lobby_join())
 				dat += "<br><font color='red'><b>To join, the round needs at least [antag.get_needed_police()] police officer(s).</b></font>"
 			else
 				dat += "<br><a href='byond://?src=\ref[src];JoinAsAntag=[antag.id]'>Join As [antag.role_text]</a>"
@@ -87,6 +91,10 @@
 /mob/new_player/proc/JoinAntag(var/datum/antagonist/antag)
 
 	if(!antag || !istype(antag, /datum/antagonist) )
+		return FALSE
+
+	if(get_lobbyjoin_antag_count() >= ticker.mode.max_antags)
+		to_chat(src, "<b>Max antag count for this gamemode reached.</b></font>")
 		return FALSE
 
 	if(selected_job in antag.restricted_jobs)
@@ -105,7 +113,7 @@
 		to_chat(src, "Limit for this antagonist group reached.")
 		return FALSE
 
-	if(!antag.meets_police_lobby_join(1))
+	if(!antag.meets_police_lobby_join())
 		to_chat(src, "This antagonist type cannot be joined until more police officers join.")
 		return FALSE
 


### PR DESCRIPTION
* Allows police scaling to work again.
* Puts in a round cap.
* Shows list of antags and their players at round end.
* Adds a non-canon gamemode we'll use for non-canon events.
