### PR TITLE
Business Cash Registers & Expense Machines

### DIFF
--- a/code/_global_vars/lists/economy_department.dm
+++ b/code/_global_vars/lists/economy_department.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(public_department_accounts)
 GLOBAL_LIST_EMPTY(private_department_accounts)
 GLOBAL_LIST_EMPTY(external_department_accounts)
 GLOBAL_LIST_EMPTY(hidden_department_accounts)
+GLOBAL_LIST_EMPTY(business_department_accounts)
 
 GLOBAL_VAR_INIT(num_financial_terminals, 1)
 GLOBAL_VAR_INIT(economy_init, 0)

--- a/code/controllers/subsystems/economy.dm
+++ b/code/controllers/subsystems/economy.dm
@@ -4,15 +4,28 @@ SUBSYSTEM_DEF(economy)
 	flags = SS_NO_FIRE
 
 	var/list/all_departments = list()
+	var/list/all_department_accounts = list()
+	var/list/all_public_depts = list()
+	var/list/all_private_depts = list()
+	var/list/all_hidden_depts = list()
+	var/list/all_business_depts = list()
+	var/list/all_money_accounts_list = list()
 
 /datum/controller/subsystem/economy/Initialize(timeofday)
 	setup_economy()
-	all_departments = GLOB.departments
 	load_economy()
 	load_business_departments()
 	init_expenses()
 	persistent_economy.load_accounts()
 	link_economy_accounts()
+
+	all_departments = GLOB.departments
+	all_department_accounts = GLOB.department_accounts
+	all_public_depts = GLOB.public_departments
+	all_private_depts = GLOB.private_departments
+	all_hidden_depts = GLOB.hidden_departments
+	all_business_depts = GLOB.business_departments
+	all_money_accounts_list = GLOB.all_money_accounts
 	. = ..()
 
 /datum/controller/subsystem/economy/proc/get_all_nonbusiness_departments()
@@ -55,10 +68,7 @@ SUBSYSTEM_DEF(economy)
 
 	for(var/obj/machinery/cash_register/CR in GLOB.transaction_devices)
 		if(CR.account_to_connect)
-			var/datum/money_account/M = dept_acc_by_id(CR.account_to_connect)
-			if(!M)
-				continue
-			CR.linked_account = M.account_number
+			CR.connect_to_dept()
 
 	for(var/obj/machinery/status_display/money_display/MD in GLOB.money_displays)
 		MD.link_to_account()

--- a/code/datums/supplypacks/circuits.dm
+++ b/code/datums/supplypacks/circuits.dm
@@ -173,3 +173,13 @@
 	cost = 3000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "Sewing Machine Circuit"
+
+
+/datum/supply_pack/circuits/expense_manager
+	contains = list(/obj/item/weapon/circuitboard/expense_manager)
+
+	name = "Expense Manager Circuit"
+	cost = 9000
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Business Expense Manager Circuit"
+

--- a/code/game/objects/items/weapons/circuitboards/other.dm
+++ b/code/game/objects/items/weapons/circuitboards/other.dm
@@ -99,3 +99,12 @@
 							/obj/item/weapon/stock_parts/subspace/transmitter = 1,
 							/obj/item/weapon/stock_parts/subspace/crystal = 1,
 							)
+
+
+/obj/item/weapon/circuitboard/expense_manager
+	name = T_BOARD("Expense Manager")
+	build_path = /obj/machinery/expense_manager/business
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_DATA = 2)
+	req_components = list(
+							/obj/item/weapon/stock_parts/capacitor = 1)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -199,9 +199,14 @@ log transactions
 							if(!isemptylist(authenticated_account.expenses))
 								dat += "<br><br><b>Debts:</b><br>"
 								for(var/datum/expense/E in authenticated_account.expenses)
+									var/dept_name
+									if(E.department)
+										dept_name = dept_name_by_id(E.department)
 									var/purpose_name
 									if(E.purpose)
 										purpose_name = " ([E.purpose])"
+										if(dept_name)
+											dat += "([dept_name]) "
 										dat += "<b>[E.name][purpose_name]:</b> [E.amount_left] credits. ([E.cost_per_payroll] per payroll.)<br>"
 							dat += "<br>"
 

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -630,7 +630,7 @@
 	var/dat = {"
 	<head><style>
 		.tx-title {text-align: center; background-color:#55a358; font-weight: bold}
-		.tx-name {background-color: #bbbbee}
+		.tx-name {background-color: #62629F}
 		.tx-data {text-align: right; background-color: #2f7832;}
 	</head></style>
 	<table width=300>

--- a/code/modules/economy/departments.dm
+++ b/code/modules/economy/departments.dm
@@ -56,20 +56,8 @@
 		starting_money = d_starting_money
 
 	make_bank_account()
-	GLOB.departments += src
 
-	switch(dept_type)
-		if(PUBLIC_DEPARTMENT)
-			GLOB.public_departments += src
-		if(PRIVATE_DEPARTMENT)
-			GLOB.private_departments += src
-		if(EXTERNAL_DEPARTMENT)
-			GLOB.external_departments += src
-		if(HIDDEN_DEPARTMENT)
-			GLOB.hidden_departments += src
-		if(BUSINESS_DEPARTMENT)
-			GLOB.business_departments += src
-			business_taxed = TRUE
+	sanitize_values()
 
 /datum/department/proc/sanitize_values()	// juuuust in case shittery happens.
 	if(!blacklisted_employees)
@@ -86,6 +74,46 @@
 
 	if(!bounties)
 		bounties = list()
+
+	if(get_business())
+		dept_type = BUSINESS_DEPARTMENT
+
+	GLOB.departments |= src
+
+	switch(dept_type)
+		if(PUBLIC_DEPARTMENT)
+			GLOB.public_departments |= src
+		if(PRIVATE_DEPARTMENT)
+			GLOB.private_departments |= src
+		if(EXTERNAL_DEPARTMENT)
+			GLOB.external_departments |= src
+		if(HIDDEN_DEPARTMENT)
+			GLOB.hidden_departments |= src
+		if(BUSINESS_DEPARTMENT)
+			GLOB.business_departments |= src
+			business_taxed = TRUE
+
+	if(bank_account)
+		switch(dept_type)
+			if(PUBLIC_DEPARTMENT)
+				GLOB.public_department_accounts |= bank_account
+			if(PRIVATE_DEPARTMENT)
+				GLOB.private_department_accounts |= bank_account
+			if(EXTERNAL_DEPARTMENT)
+				GLOB.external_department_accounts |= bank_account
+			if(HIDDEN_DEPARTMENT)
+				GLOB.hidden_department_accounts |= bank_account
+				bank_account.hidden = TRUE
+			if(BUSINESS_DEPARTMENT)
+				GLOB.business_department_accounts |= bank_account
+
+		if(!(bank_account in GLOB.department_accounts))
+			GLOB.department_accounts |= bank_account
+
+		if(!(bank_account in GLOB.all_money_accounts))
+			GLOB.all_money_accounts.Add(bank_account)
+
+
 
 	return TRUE
 
@@ -139,19 +167,8 @@
 		return FALSE
 
 	bank_account = create_account(name, starting_money, null, department = TRUE)
-	bank_account.department = src
-	GLOB.department_accounts += bank_account
+	bank_account.department = id
 
-	switch(dept_type)
-		if(PUBLIC_DEPARTMENT)
-			GLOB.public_department_accounts += bank_account
-		if(PRIVATE_DEPARTMENT)
-			GLOB.private_department_accounts += bank_account
-		if(EXTERNAL_DEPARTMENT)
-			GLOB.external_department_accounts += bank_account
-		if(HIDDEN_DEPARTMENT)
-			GLOB.hidden_department_accounts += bank_account
-			bank_account.hidden = TRUE
 
 	return bank_account
 

--- a/code/modules/economy/expense_manager.dm
+++ b/code/modules/economy/expense_manager.dm
@@ -1,6 +1,6 @@
 /obj/machinery/expense_manager
 	name = "expense manager"
-	desc = "Swipe your ID card to manage expenses for a bank account. Put in the client's ID, not your own."
+	desc = "Swipe your ID card to set up a pay-in-chunks direct debt for a bank account. Useful if customers cannot pay in full. Put in the client's ID, not your own."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "expense"
 	flags = NOBLUDGEON
@@ -17,6 +17,36 @@
 	var/icon_state_active = "expense_1"
 	var/icon_state_inactive = "expense"
 	var/expense_limit = 500000			// highest expense you can set.
+	var/payroll_limit = 150 // max that can be charged per payroll
+
+	var/business_id = ""
+	var/business = FALSE
+
+	var/owner_name = ""
+	var/owner_uid = ""
+	unique_save_vars = list("business_id", "owner_name", "owner_uid")
+
+	var/current_operator = ""
+
+	dont_save = TRUE
+
+
+
+/obj/machinery/expense_manager/business
+	name = "business expense manager"
+	business = TRUE
+	req_access = list()
+	expense_limit = 100000
+	dont_save = FALSE
+	circuit = /obj/item/weapon/circuitboard/expense_manager
+
+/obj/machinery/expense_manager/business/examine(mob/user)
+	..()
+	if(expense_limit)
+		to_chat(user, "The expense limit is <b>[expense_limit]CR.</b>")
+	var/datum/business/B = get_business_by_biz_uid(business_id)
+	if(B)
+		to_chat(user, "<b>It is registered to [B.name].</b>")
 
 /obj/machinery/expense_manager/update_icon()
 	if(stored_id)
@@ -44,9 +74,15 @@
 
 /obj/machinery/expense_manager/attackby(obj/item/I, mob/user)
 
+	if(!I)
+		return
 
 	if (!istype(I, /obj/item/weapon/card/id) && !stored_id)
 		to_chat(user, "\icon[src] <span class='warning'>Error: [src] can only accept identification cards.</span>")
+		return
+
+	if(business && !business_id)
+		set_new_owner(I, user)
 		return
 
 	if(stored_id)
@@ -56,8 +92,10 @@
 	if(insert_id(I, user))
 		var/obj/item/weapon/card/id/iden = user.GetIdCard()
 
-		if(!check_access(iden))
+		if(!iden || !check_access(iden))
 			return
+
+		current_operator = iden.registered_name
 
 		to_chat(user, "You place [I] into [src].")
 		playsound(src, 'sound/machines/chime.ogg', 25)
@@ -66,6 +104,22 @@
 		interact(user)
 	else
 		to_chat(user, "\icon[src] <span class='warning'>Error: Unable to accept ID card, this may be due to incorrect details. Contact an administrator for more information.</span>")
+
+/obj/machinery/expense_manager/proc/set_new_owner(obj/item/O, mob/user)
+	if(!istype(O, /obj/item/weapon/card/id))
+		return
+	var/obj/item/weapon/card/id/I = O
+	var/datum/business/B = get_business_by_owner_uid(I.unique_ID)
+	if(!B)
+		to_chat(usr, "\icon[src]<span class='warning'>No business detected, please register one first.</span>")
+		return
+	if(!dept_acc_by_id(B.business_uid))
+		to_chat(usr, "\icon[src]<span class='warning'>No business bank account detected, please contact an administrator.</span>")
+		return
+	to_chat(usr, "\icon[src]<span class='notice'>Business set to [B.name].</span>")
+	business_id = B.business_uid
+	owner_uid = I.unique_ID
+	owner_name = I.registered_name
 
 /obj/machinery/expense_manager/proc/insert_id(obj/item/weapon/card/id/I, mob/user)
 	current_account = get_account(I.associated_account_number)
@@ -138,6 +192,10 @@
 		to_chat(user, "\icon[src] <span class='warning'>Error: You do not have access to this terminal.</span>")
 		return
 
+	if(!iden || !iden.registered_name || !iden.unique_ID)
+		to_chat(user, "\icon[src] <span class='warning'>Error: You need a valid ID card to use this terminal.</span>")
+		return
+
 	interact(user)
 	updateDialog()
 
@@ -168,13 +226,15 @@
 			var/list/datum/expense/expense_list = list()
 
 			for(var/datum/expense/E in current_account.expenses)
+				if(business && (E.department != business_id))
+					continue
 				if (istype(E, expense_type))
 					expense_list += E
 
 			//show expenses
 			dat += "<br><h2>Debts:</h2><hr>"
 
-			if(!isemptylist(expense_list))
+			if(LAZYLEN(expense_list))
 				for(var/datum/expense/E in expense_list)
 
 					dat += "<fieldset style='border: 2px solid [E.color]; display: inline'>"
@@ -184,14 +244,20 @@
 					dat += "<br>Current Debt Left: [E.amount_left] credits."
 					dat += "<br>Added By: [E.added_by]"
 					dat += "<br>Creation Date: [E.creation_date]"
+					var/dept_name = dept_name_by_id(E.department)
+					if(dept_name)
+						dat += "<br>Department: [dept_name]"
+
 					dat += "<br>Status: [E.active ? "Active" : "Inactive"]<br><br>"
+
+
 
 					dat += "<br>Comments: <i>[E.comments]</i><br>"
 
 					dat += "<a href='?src=\ref[src];choice=edit_expense;expense=\ref[E]''>Edit Expense</a> "
 					dat += "<a href='?src=\ref[src];choice=remove_expense;expense=\ref[E]''>Remove Expense</a> "
 					dat += "<a href='?src=\ref[src];choice=toggle_expense;expense=\ref[E]'>Toggle Expense</a> "
-
+					dat += "<a href='?src=\ref[src];choice=adjust_payroll;expense=\ref[E]'>Adjust Per-Payroll</a> "
 					dat += "</fieldset>"
 
 					dat += "<br>"
@@ -206,6 +272,7 @@
 		onclose(user, "expense_machine")
 
 /obj/machinery/expense_manager/proc/add_new_expense(mob/user)
+
 	var/expense_purpose = sanitize(input("Enter the purpose of this expense.", "Expense Purpose") as text)
 	if(!expense_purpose) return
 
@@ -218,28 +285,66 @@
 	if(!expense_commments) return
 
 
-	var/new_expense = create_expense(expense_type, expense_purpose, expense_commments, expense_amount, user.name, user.ckey)
+	var/datum/expense/new_expense = create_expense(expense_type, expense_purpose, expense_commments, expense_amount, user.name, user.ckey)
+	if(!new_expense) return
+
+	if(business && business_id)
+		var/datum/business/B = get_business_by_biz_uid(business_id)
+		if(B)
+			new_expense.department = B.business_uid
 
 	current_account.expenses += new_expense
 
+	var/datum/money_account/M = dept_acc_by_id(new_expense.department)
+	if(M)
+		M.add_transaction_log("[new_expense.name]: New Expense", "Expense registered to [current_account.owner_name]'s account authorised by [current_operator] (Charged Account ID: [current_account.account_number]). | Amount: [expense_amount]CR | Purpose: [expense_purpose]", 0)
+		current_account.add_transaction_log("[new_expense.name]: New Expense", "Received new expense from [M.owner_name] authorised by [current_operator] (Charging Account ID: [M.account_number]). | Amount: [expense_amount]CR | Purpose: [expense_purpose]", 0)
+		log_money(user, "added expense to [current_account.owner_name]: [new_expense.name]. (Charging Account ID: [M.account_number]). | Amount: [expense_amount]CR | Purpose: [expense_purpose]", current_account.account_number, current_account.owner_name, expense_amount)
+
 
 /obj/machinery/expense_manager/proc/remove_expense(mob/user, var/datum/expense/E)
+	if(!E)
+		return
+
 	var/choice = alert(user,"Would you like to remove this expense?","Remove Expense","No","Yes")
 	if(choice == "Yes")
 		current_account.expenses -= E
+
+		var/datum/money_account/M = dept_acc_by_id(E.department)
+		if(M)
+			M.add_transaction_log("[E.name]: Removed Expense", "Expense removed from [current_account.owner_name]'s account authorised by [current_operator]", 0)
+			current_account.add_transaction_log("[E.name]: Removed Expense", "Expense removed: [M.owner_name] authorised by [current_operator] (Charging Account ID: [M.account_number])", 0)
+			log_money(user, "[E.name]: Removed expense from [current_account.owner_name]: [E.name]. (Charging Account ID: [M.account_number]), current_account.account_number, current_account.owner_name", 0)
 		qdel(E)
-	else
-		return
+
+
+		return TRUE
+
+	return FALSE
 
 /obj/machinery/expense_manager/proc/suspend_expense(mob/user, var/datum/expense/E)
-	var/choice = alert(user,"[E.active ? "Suspend" : "Un-suspend"] this expense?","Suspend Expense","Suspend","Un-Suspend")
-	if(choice == "Suspend")
-		if(E.active)
-			E.active = 0
-	else
-		E.active = 1
+	if(!E)
+		return
+
+	var/choice = alert(user,"[E.active ? "Suspend" : "Un-suspend"] this expense?","Suspend Expense","Yes","No")
+	if(choice == "Yes")
+		E.active = !E.active
+
+		var/datum/money_account/M = dept_acc_by_id(E.department)
+		if(M)
+			M.add_transaction_log("[E.name]: [E.active ? "un" : ""]suspended Expense", "Expense [E.active ? "un" : ""]suspended from [current_account.owner_name]'s account authorised by [current_operator] (Charged Account ID: [current_account.account_number]).", 0)
+			current_account.add_transaction_log("[E.name]: [E.active ? "un" : ""]suspended Expense", "Expense [E.active ? "un" : ""]suspended: Expense from [M.owner_name], authorised by [current_operator] (Charging Account ID: [M.account_number]).", 0)
+			log_money(user, "suspended expense to [current_account.owner_name]: [E.name]. ", current_account.account_number, current_account.owner_name, 0)
+
+		return
+
+
+	return FALSE
 
 /obj/machinery/expense_manager/proc/edit_expense(mob/user, var/datum/expense/E)
+	if(!E)
+		return
+
 	var/expense_purpose = sanitize_text(input(usr, "Enter the purpose of this expense.", "Expense Purpose", E.name)  as text,1,25)
 	if(!expense_purpose) return
 
@@ -256,6 +361,15 @@
 	if(!(user.ckey in E.ckey_edit_list))
 		E.ckey_edit_list += user.ckey
 
+	E.cost_per_payroll = Clamp(E.cost_per_payroll, 0, E.amount_left)
+
+	var/datum/money_account/M = dept_acc_by_id(E.department)
+	if(M)
+		M.add_transaction_log("[E.name]: Edited Expense", "Edited Expense on [current_account.owner_name]'s account authorised by [current_operator] (Charged Account ID: [current_account.account_number]). | Amount: [expense_amount]CR | Purpose: [expense_purpose]", 0)
+		current_account.add_transaction_log("[E.name]: Suspended Expense", "Expense edited: Expense from [M.owner_name] edited, authorised by [current_operator] (Charging Account ID: [M.account_number]) | Amount: [expense_amount]CR | Purpose: [expense_purpose]", 0)
+		log_money(user, "edited expense to [current_account.owner_name]: [E.name]. | Amount: [expense_amount]CR | Purpose: [expense_purpose] | Comments: [expense_commments]", current_account.account_number, current_account.owner_name, 0)
+
+
 /obj/machinery/expense_manager/proc/remove_all_expenses(mob/user)
 
 	if(!current_account)
@@ -264,14 +378,31 @@
 		var/choice = alert(user,"Delete all expenses from account? This cannot be undone!","Delete Expense","No","Yes")
 		if(choice == "Yes")
 			for(var/datum/expense/E in current_account.expenses)
+				if(business && (E.department != business_id))
+					continue
 				if (istype(E, expense_type))
 					current_account.expenses -= E
+
+			var/datum/money_account/M = dept_acc_by_id(business_id)
+			if(M)
+				M.add_transaction_log("Expense Removal", "All expenses removed for [current_account.owner_name]'s account authorised by [current_operator] (Charged Account ID: [current_account.account_number]).", 0)
+				current_account.add_transaction_log("Expense Removal", "All expense removed: All expenses from [M.owner_name] removed, authorised by [current_operator] (Charging Account ID: [M.account_number]).", 0)
+				log_money(user, "all expenses removed from [current_account.owner_name]. ", current_account.account_number, current_account.owner_name, 0)
+
 		else if(choice == "No")
 			return
 
 /obj/machinery/expense_manager/Topic(var/href, var/href_list)
 	if(..())
 		return 1
+
+	var/obj/item/weapon/card/id/iden = usr.GetIdCard()
+
+	if(!check_access(iden))
+		return
+
+	current_operator = iden.registered_name
+
 	if(href_list["choice"])
 		switch(href_list["choice"])
 
@@ -285,6 +416,27 @@
 			if("toggle_expense")
 				var/E = locate(href_list["expense"])
 				suspend_expense(usr, E)
+
+			if("adjust_payroll")
+				var/E = locate(href_list["expense"])
+				if(!E) return
+				var/datum/expense/exp = E
+				var/payroll_amt = sanitize_integer(input(usr, "Enter expense amount (in credits). Max: [payroll_limit]", "Expense Amount", exp.cost_per_payroll)  as num|null, 1, 1000)
+				if(!payroll_amt || (payroll_amt > payroll_limit))
+					to_chat(usr, "Please enter a valid amount!")
+					return
+
+				payroll_amt = Clamp(exp.cost_per_payroll, 0, exp.amount_left)
+
+
+				var/datum/money_account/M = dept_acc_by_id(exp.department)
+				if(M)
+					M.add_transaction_log("[exp.name]: Expense Adjustment", "Expense payroll rate adjustment to [payroll_amt]CR [current_account.owner_name]'s account authorised by [current_operator]", 0)
+					current_account.add_transaction_log("[exp.name]: Adjusted Expense", "Expense payroll adjusted to [payroll_amt]CR: [M.owner_name] authorised by [current_operator] (Charging Account ID: [M.account_number])", 0)
+					log_money(usr, "[exp.name]: Changed payroll rate of [current_account.owner_name] to [payroll_amt]CR: [exp.name]. (Charging Account ID: [M.account_number]), current_account.account_number, current_account.owner_name", 0)
+
+
+				exp.cost_per_payroll = payroll_amt
 
 			if("edit_expense")
 				var/E = locate(href_list["expense"])

--- a/code/modules/government/business/business_helpers.dm
+++ b/code/modules/government/business/business_helpers.dm
@@ -72,6 +72,11 @@ var/global/list/business_outfits = list(
 /datum/business/proc/get_department()
 	return dept_by_id(department)
 
+/datum/business/proc/get_department_id()
+	var/datum/department/D = get_department()
+	if(D)
+		return D.id
+
 /proc/businesses_by_category(cat)
 	var/list/biz = list()
 	for(var/datum/business/B in GLOB.all_businesses)

--- a/code/modules/government/credit/expenses.dm
+++ b/code/modules/government/credit/expenses.dm
@@ -1,6 +1,6 @@
 /datum/expense
   var/name = "Generic Expense"
-  var/cost_per_payroll = 1          // per payroll
+  var/cost_per_payroll = 20          // per payroll
   var/department = DEPT_COUNCIL
   var/purpose = "Bill"
 
@@ -10,7 +10,7 @@
 
   var/initial_cost				//how much it cost in the beginning
 
-  var/amount_left
+  var/amount_left = 0
 
   var/active = TRUE		               // If this is currently active, or not.
 
@@ -38,6 +38,9 @@
 		return 0
 
 	var/charge
+
+	if(cost_per_payroll > amount_left)
+		cost_per_payroll = amount_left
 
 	if(num > amount_left)
 		charge += amount_left
@@ -91,6 +94,10 @@
 /proc/charge_expense(var/datum/expense/E, var/datum/money_account/bank_account, var/num)
 	if(!E.is_active())
 		return 0
+
+	if(E.cost_per_payroll > E.amount_left)
+		E.cost_per_payroll = E.amount_left
+		num = E.amount_left
 
 	E.process_charge(num)
 	bank_account.money -= num


### PR DESCRIPTION
* Cash registers are now registered to a business instead of a singular bank account.
* You can adjust prices of individual items that you scan now.
* You can now display the item list of things you have scanned to the customer.
* Cash registers now use the non-basic UI.
* ATMs tell you what department your expense is from.
* Expenses Managers can be bought from factory, they use a machine circuitboard.
* Added admin logging and transaction logging for transparency and anti-abuse for expense managers.
* Business departments should no longer show up on presidential portal, I think.
