### PR TITLE
External Limb Surgery, and Autopsy Scanner Fix

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -32,11 +32,15 @@ HALOGEN COUNTER	- Radcount on mobs
 		verbs += /obj/item/device/healthanalyzer/proc/toggle_adv
 	..()
 
-/obj/item/device/healthanalyzer/do_surgery(mob/living/M, mob/living/user)
-//	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
-//		return ..()
-	scan_mob(M, user) //default surgery behaviour is just to scan as usual
-	return 1
+	
+/obj/item/device/healthanalyzer/do_surgery(mob/living/carbon/human/M, mob/living/user)
+	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
+	if(S.open)
+		return ..()
+		
+	else
+		scan_mob(M, user)
+	
 
 /obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/user)
 	scan_mob(M, user)

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -162,9 +162,6 @@
 	if(!istype(M))
 		return 0
 
-//	if (user.a_intent == I_HELP)
-//		return ..()
-
 	if(target_name != M.name)
 		target_name = M.name
 		src.wdata = list()
@@ -175,14 +172,18 @@
 	src.timeofdeath = M.timeofdeath
 
 	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
-	if(!S)
-		to_chat(user, "<span class='warning'>You can't scan this body part.</span>")
-		return
-	if(!S.open)
-		to_chat(user, "<span class='warning'>You have to cut [S] open first!</span>")
-		return
-	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
+	if (S.open == 2)
+		return ..()
+	else
+		if(!S)
+			to_chat(user, "<span class='warning'>You can't scan this body part.</span>")
+			return
+		if(!S.open)
+			to_chat(user, "<span class='warning'>You have to cut [S] open first!</span>")
+			return
+		M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
 
-	src.add_data(S)
+		src.add_data(S)
 
-	return 1
+		return 1
+


### PR DESCRIPTION
Enabled the use of Health Analyzers in the use of external limb surgery.
Modified the Autopsy Scanner to allow both use in surgery and to generate autopsy reports.
Both scanners use the Help intent with out need to swap to grab or another intent to perform both functions.


code: Changed code for both scanners to look for the surgical step of having an open zone, rather than have an intent