### PR TITLE
[Speedmerge] Prevents Inv-Tri Item Duplication Glitch

### DIFF
--- a/code/modules/persistence/persistent_inventory.dm
+++ b/code/modules/persistence/persistent_inventory.dm
@@ -32,6 +32,10 @@
 
 	circuit = /obj/item/weapon/circuitboard/inventory_box
 
+	save_contents = FALSE
+
+	var/item_processing = FALSE
+
 
 /obj/machinery/inventory_machine/New()
 	..()
@@ -257,6 +261,7 @@
 			return
 
 		if(!emagged)
+
 			var/list/contents_to_search = list()
 			contents_to_search += I.get_saveable_contents()
 			contents_to_search += I
@@ -452,6 +457,9 @@
 		atmpt_maint_mode = TRUE
 
 	if(href_list["cancel"])
+		if(item_processing)
+			return FALSE
+
 		atmpt_maint_mode = FALSE
 		maint_mode = FALSE
 		current_inventory = null
@@ -589,15 +597,27 @@
 	GLOB.persistent_inventories += src
 
 /datum/persistent_inventory/proc/add_item(var/obj/item/O, mob/user)
+	if(item_processing)
+		return FALSE
 	if(disallowed_items.len && is_type_in_list(O, disallowed_items))
 		return FALSE
 
+
+	I.forceMove(src) // move item into it to prevent glitches.
+
+	item_processing = TRUE
+
 	var/datum/map_object/MO = full_item_save(O)
+
+
+
 
 	stored_items += MO
 	if(user)
 		to_chat(user, "You add [O] to the storage.")
 	qdel(O)
+
+	item_processing = FALSE
 
 	return MO
 

--- a/code/modules/persistence/persistent_inventory.dm
+++ b/code/modules/persistence/persistent_inventory.dm
@@ -251,6 +251,9 @@
 		return
 
 	if(current_inventory)
+		if(item_processing)
+			visible_message("<b>[src]</b> beeps, \"<span class='danger'>Please wait!</span>\" ")
+			return FALSE
 		if(I.dont_save)
 			visible_message("<b>[src]</b> beeps, \"<span class='danger'>I'm sorry! I'm unable to accept this item!</span>\" ")
 			flick("inv-tri_warn",src)
@@ -272,7 +275,14 @@
 					visible_message("<b>[src]</b> beeps, \"<span class='danger'>I can't take this item as it is a government controlled item, I'm sorry!</span>\" ")
 					flick("inv-tri_warn",src)
 					return
+
+
+		item_processing = TRUE
+		I.forceMove(src) // move item into it to prevent glitches.
+
 		current_inventory.add_item(I, user)
+
+		item_processing = FALSE
 		updateDialog()
 		update_icon()
 		return
@@ -597,27 +607,15 @@
 	GLOB.persistent_inventories += src
 
 /datum/persistent_inventory/proc/add_item(var/obj/item/O, mob/user)
-	if(item_processing)
-		return FALSE
 	if(disallowed_items.len && is_type_in_list(O, disallowed_items))
 		return FALSE
 
-
-	I.forceMove(src) // move item into it to prevent glitches.
-
-	item_processing = TRUE
-
 	var/datum/map_object/MO = full_item_save(O)
-
-
-
 
 	stored_items += MO
 	if(user)
 		to_chat(user, "You add [O] to the storage.")
 	qdel(O)
-
-	item_processing = FALSE
 
 	return MO
 


### PR DESCRIPTION
Urgent hotfix. The glitch secret's out. Need to prevent big bags or other laggy items from being duped (since saving can lag for huge objs)

This moves the item in the invtri before the saving starts (which should solve the issue) but also as an extra layer of security by making the inv-tri stop working if it's processing an item.
