### PR TITLE
Removes zippo explosives from the traitor uplink.

### DIFF
--- a/code/datums/uplink/tools.dm
+++ b/code/datums/uplink/tools.dm
@@ -95,22 +95,22 @@
 	name = "Thermal Imaging Glasses"
 	item_cost = 30
 	path = /obj/item/clothing/glasses/thermal/syndi
-
+/*
 /datum/uplink_item/item/tools/packagebomb
 	name = "Package Bomb (Small)"
 	item_cost = 30
 	path = /obj/item/weapon/storage/box/syndie_kit/demolitions
-
+*/
 /datum/uplink_item/item/tools/powersink
 	name = "Powersink (DANGER!)"
 	item_cost = 40
 	path = /obj/item/device/powersink
-
+/*
 /datum/uplink_item/item/tools/packagebomb/large
 	name = "Package Bomb (Large)"
 	item_cost = 60
 	path = /obj/item/weapon/storage/box/syndie_kit/demolitions_heavy
-
+*/
 /*
 /datum/uplink_item/item/tools/packagebomb/huge
 	name = "Package Bomb (Huge)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Commented out the small and medium zippo explosives from the traitor uplink. The large explosive was already commented out. The explosives themselves are still in the game, but now they're only obtainable with admin spawn.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Jack Knight wants to have his `days since last bombing` counter have a chance to go above 2.
But in seriousness, low effort explosives are bad for the game imo and it seems Cassie agrees, since other explosives were removed but the zippos got left in. Not sure if that was a mistake or not but I got asked to finish easy bombs off.
Requested by @GeneriedJenelle .
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes Zippo explosives from the traitor uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->