### PR TITLE
Material Fixes + Smartfridge Changes

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -129,7 +129,6 @@
 	drop_sound = 'sound/items/drop/glass.ogg'
 	associated_reagents = list("carbon")
 
-
 /obj/item/stack/material/uranium
 	name = "uranium"
 	icon_state = "sheet-uranium"
@@ -579,6 +578,8 @@
 	icon_state = "sheet-void_opal"
 	singular_name = "void opal"
 	default_type = "void opal"
+	stack_color = "#292929"
+	apply_colour = 1
 	no_variants = FALSE
 
 /obj/item/stack/material/quartz

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -67,7 +67,7 @@ var/list/name_to_material
 	var/display_name                      // Prettier name for display.
 	var/use_name
 	var/flags = 0                         // Various status modifiers.
-	var/sheet_singular_name = "sheet"
+	var/sheet_singular_name = "sheets"
 	var/sheet_plural_name = "sheets"
 	var/is_fusion_fuel
 
@@ -258,6 +258,8 @@ var/list/name_to_material
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 100
 	stack_origin_tech = list(TECH_MATERIAL = 6)
+	sheet_singular_name = "gems"
+	sheet_plural_name = "gems"
 
 /material/gold
 	name = "gold"
@@ -268,13 +270,13 @@ var/list/name_to_material
 	hardness = 40
 	conductivity = 41
 	stack_origin_tech = list(TECH_MATERIAL = 4)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/gold/bronze //placeholder for ashtrays
 	name = "bronze"
 	stack_type = /obj/item/stack/material/bronze
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 	icon_colour = "#EDD12F"
 
@@ -286,7 +288,7 @@ var/list/name_to_material
 	hardness = 50
 	conductivity = 63
 	stack_origin_tech = list(TECH_MATERIAL = 3)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 //R-UST port
@@ -301,7 +303,7 @@ var/list/name_to_material
 	shard_type = SHARD_SHARD
 	hardness = 30
 	door_icon_base = "stone"
-	sheet_singular_name = "crystal"
+	sheet_singular_name = "crystals"
 	sheet_plural_name = "crystals"
 	is_fusion_fuel = 1
 
@@ -315,7 +317,7 @@ var/list/name_to_material
 	hardness = 30
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_PHORON = 2)
 	door_icon_base = "stone"
-	sheet_singular_name = "crystal"
+	sheet_singular_name = "crystals"
 	sheet_plural_name = "crystals"
 
 /*
@@ -347,7 +349,7 @@ var/list/name_to_material
 	protectiveness = 5 // 20%
 	conductivity = 5
 	door_icon_base = "stone"
-	sheet_singular_name = "brick"
+	sheet_singular_name = "bricks"
 	sheet_plural_name = "bricks"
 
 /material/stone/marble
@@ -454,7 +456,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/osmium
 	icon_colour = "#9999FF"
 	stack_origin_tech = list(TECH_MATERIAL = 5)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/tritium
@@ -462,7 +464,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/tritium
 	icon_colour = COLOR_TRITIUM
 	stack_origin_tech = list(TECH_MATERIAL = 5)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 	is_fusion_fuel = 1
 
@@ -471,7 +473,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/deuterium
 	icon_colour = "#999999"
 	stack_origin_tech = list(TECH_MATERIAL = 3)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 	is_fusion_fuel = 1
 
@@ -490,7 +492,7 @@ var/list/name_to_material
 	weight = 27
 	conductivity = 9.43
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/iron
@@ -499,7 +501,7 @@ var/list/name_to_material
 	icon_colour = "#5C5454"
 	weight = 22
 	conductivity = 10
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/lead
@@ -508,7 +510,7 @@ var/list/name_to_material
 	icon_colour = COLOR_LEAD
 	weight = 23 // Lead is a bit more dense than silver IRL, and silver has 22 ingame.
 	conductivity = 10
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 	radiation_resistance = 25 // Lead is Special and so gets to block more radiation than it normally would with just weight, totalling in 48 protection.
 
@@ -597,7 +599,7 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 1)
 	melting_point = T0C+1
 	destruction_desc = "crumbles"
-	sheet_singular_name = "brick"
+	sheet_singular_name = "bricks"
 	sheet_plural_name = "bricks"
 	radiation_resistance = 1
 
@@ -610,7 +612,7 @@ var/list/name_to_material
 	icon_colour = "#402821"
 	icon_reinf = "reinf_cult"
 	shard_type = SHARD_STONE_PIECE
-	sheet_singular_name = "brick"
+	sheet_singular_name = "bricks"
 	sheet_plural_name = "bricks"
 
 /material/cult/place_dismantled_girder(var/turf/target)
@@ -809,7 +811,7 @@ var/list/name_to_material
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 100
 	stack_origin_tech = list(TECH_ARCANE = 1, TECH_MATERIAL = 6)
-	sheet_singular_name = "gem"
+	sheet_singular_name = "gems"
 	sheet_plural_name = "gems"
 
 /material/painite
@@ -819,7 +821,7 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/painite
 	flags = MATERIAL_UNMELTABLE
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	sheet_singular_name = "gem"
+	sheet_singular_name = "gems"
 	sheet_plural_name = "gems"
 
 /material/tin
@@ -827,7 +829,7 @@ var/list/name_to_material
 	display_name = "tin"
 	use_name = "tin"
 	stack_type = /obj/item/stack/material/tin
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/copper
@@ -836,7 +838,7 @@ var/list/name_to_material
 	use_name = "copper"
 	stack_type = /obj/item/stack/material/copper
 	conductivity = 52
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"
 
 /material/quartz
@@ -845,7 +847,7 @@ var/list/name_to_material
 	use_name = "quartz"
 	stack_type = /obj/item/stack/material/quartz
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	sheet_singular_name = "crystal"
+	sheet_singular_name = "crystals"
 	sheet_plural_name = "crystals"
 
 /material/aluminium
@@ -853,5 +855,5 @@ var/list/name_to_material
 	display_name = "aluminium"
 	use_name = "aluminium"
 	stack_type = /obj/item/stack/material/aluminium
-	sheet_singular_name = "ingot"
+	sheet_singular_name = "ingots"
 	sheet_plural_name = "ingots"

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -101,7 +101,7 @@
 /obj/item/weapon/ore/rutile
 	name = "rutile"
 	icon_state = "ore_rutile"
-	material = "rutile"
+	material = "titanium"
 
 /obj/item/weapon/ore/void_opal
 	name = "raw void opal"

--- a/nano/templates/smartfridge.tmpl
+++ b/nano/templates/smartfridge.tmpl
@@ -22,8 +22,8 @@
 		{{if value.quantity >= 10}}
 			{{:helper.link('x10', 'circle-arrow-s', { "vend" : value.vend, "amount" : 10 }, null, 'statusValue')}}
 		{{/if}}
-		{{if value.quantity >= 25}}
-			{{:helper.link('x25', 'circle-arrow-s', { "vend" : value.vend, "amount" : 25 }, null, 'statusValue')}}
+		{{if value.quantity >= 10}}
+			{{:helper.link('x10', 'circle-arrow-s', { "vend" : value.vend, "amount" : 10 }, null, 'statusValue')}}
 		{{/if}}
       </div>
     {{/for}}

--- a/nano/templates/smartfridge.tmpl
+++ b/nano/templates/smartfridge.tmpl
@@ -25,9 +25,6 @@
 		{{if value.quantity >= 25}}
 			{{:helper.link('x25', 'circle-arrow-s', { "vend" : value.vend, "amount" : 25 }, null, 'statusValue')}}
 		{{/if}}
-		{{if value.quantity > 1}}
-			{{:helper.link('All', 'circle-arrow-s', { "vend" : value.vend, "amount" : value.quantity }, null, 'statusValue')}}
-		{{/if}}
       </div>
     {{/for}}
   {{else}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Void Opal material items now have a color

- Rutile will now properly smelt to titanium (Sorry, I swear I fixed this in a previous PR somewhere)

- All sheets no longer have a singular name when there is 1 sheet left in the amount. ("ingot" to "ingots", etc.) For sorting purposes. 

- Smartfridges can no longer vend x25 or vend ALL. In its current state, large stacks will instantly crash the server and it will be unable to restart for ~15-20 minutes. (See: Jolly Farm disaster of July 2564)

 - Diamond sheets are now Diamond gems.



## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevent crashes, fix bugs. Always good.
## Changelog
:cl:
add: Void opal materials now have a color.
del: Removed x25 and ALL option from smartfridges.
fix: Rutile properly smelts to titanium.
tweak: Singular names for sheets changed to match plural.
tweak: Diamond sheets now diamond gems.
del: Adolescent Thermonuclear Shinobi Sheep removed from sewer mob spawners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->