### PR TITLE
Updates thug and traitor thresholds

### DIFF
--- a/code/game/antagonist/station/thug.dm
+++ b/code/game/antagonist/station/thug.dm
@@ -19,7 +19,7 @@
 	initial_spawn_req = 2
 	initial_spawn_target = 4
 	hard_cap = 8
-	police_per_antag = 3
+	police_per_antag = 2
 	minimum_player_age = 1
 
 	//Thugs get their own universal outfit, each round.

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -12,7 +12,7 @@ var/datum/antagonist/traitor/traitors
 	You are still expected to escalate accordingly. Try to make sure other players have fun! AOOC is enabled, but please do not metagame. \
 	<b>This role has uplink items.</b>"
 	allow_lobbyjoin = TRUE
-	police_per_antag = 5
+	police_per_antag = 3
 
 	minimum_player_age = 7
 


### PR DESCRIPTION
Now things have calmed down. The new antag ratios are as follows:

Traitor: Requires three police.
Thug: Requires two police.
=