### PR TITLE
Positronic Intelligence ID + Business Permits

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -789,10 +789,10 @@ SUBSYSTEM_DEF(jobs)
 			var/obj/item/clothing/accessory/permit/drone/permit = new/obj/item/clothing/accessory/permit/drone(get_turf(H))
 			permit.set_name(H.real_name)
 			H.equip_to_slot_or_del(permit, slot_in_backpack)
-/*		if(FBP_POSI) //Uncomment this when synths are mandated to have identification cards
+		if(FBP_POSI)
 			var/obj/item/clothing/accessory/permit/synth/permit = new/obj/item/clothing/accessory/permit/synth(get_turf(H))
 			permit.set_name(H.real_name)
-			H.equip_to_slot_or_del(permit, slot_in_backpack)	*/
+			H.equip_to_slot_or_del(permit, slot_in_backpack)
 
 
 

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -795,7 +795,6 @@ SUBSYSTEM_DEF(jobs)
 			H.equip_to_slot_or_del(permit, slot_in_backpack)
 
 
-
 /datum/controller/subsystem/jobs/proc/get_active_police()
 
 	var/active_popo = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Synths spawn with synth id cards.
City Clerk's locker now has business permits (about time)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Presidential mandate fulfilled.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: synths spawn with synth id cards
add: city clerk's locker now contains business permits
remove: secret portal to propus removed from away gate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->