### PR TITLE
Bugfixes: Oct Edition Part 1

### DIFF
--- a/code/game/machinery/modular_signs.dm
+++ b/code/game/machinery/modular_signs.dm
@@ -12,6 +12,8 @@
 	density = FALSE
 	plane = ABOVE_PLANE
 
+	wall_drag = TRUE
+
 	var/sign_text = "Sign Here"
 	var/sign_desc = "This is a preset sign that needs a description."
 

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -290,7 +290,7 @@
 	maptext_height = 26
 	maptext_width = 62
 	font_color = "#84ff00"
-	var/business = FALSE
+	var/business = TRUE
 
 	unique_save_vars = list("department")
 

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -107,14 +107,14 @@
  * Researchable Scalpels
  */
 /obj/item/weapon/surgical/scalpel/laser1
-	name = "laser scalpel"
+	name = "improved laser scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field.  This one looks basic and could be improved."
 	icon_state = "scalpel_laser1_on"
 	damtype = "fire"
 	hitsound = 'sound/weapons/saw/circsawhit.ogg'
 
 /obj/item/weapon/surgical/scalpel/laser2
-	name = "laser scalpel"
+	name = "advanced laser scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field.  This one looks somewhat advanced."
 	icon_state = "scalpel_laser2_on"
 	damtype = "fire"
@@ -122,7 +122,7 @@
 	drop_sound = 'sound/items/drop/accessory.ogg'
 
 /obj/item/weapon/surgical/scalpel/laser3
-	name = "laser scalpel"
+	name = "superior laser scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field.  This one looks to be the pinnacle of precision energy cutlery!"
 	icon_state = "scalpel_laser3_on"
 	damtype = "fire"

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -230,7 +230,7 @@
 										<td>[T.date] [T.time]</td>
 										<td>[T.target_name]</td>
 										<td>[T.purpose]</td>
-										<td>[cash2text(T.amount, FALSE, TRUE, TRUE )]</td>
+										<td>[T.amount]</td>
 										<td>[T.source_terminal]</td>
 									</tr>
 							"}

--- a/code/modules/maps/world_writer/world_map.dm
+++ b/code/modules/maps/world_writer/world_map.dm
@@ -85,17 +85,17 @@
 			if(islist(O.vars[V]))
 				var/list/M = O.vars[V]
 				for(var/P in M)
-					if(!istext(P) && !isnum(P))
+					if(!istext(P) && !isnum(P) && !ispath(P))
 						save_var = FALSE
 						continue
 					if(listgetindex(M,P))
 						var/asso_var = listgetindex(M,P)
-						if(asso_var && (!istext(asso_var) && !isnum(asso_var)) )
+						if(asso_var && (!istext(asso_var) && !isnum(asso_var) && !ispath(asso_var)) )
 							save_var = FALSE
 							continue
 
 			else
-				if(!istext(O.vars[V]) && !isnum(O.vars[V]))	// make sure all references to mobs/objs/turfs etc, are fully cut!
+				if(!istext(O.vars[V]) && !isnum(O.vars[V]) && !ispath(O.vars[V]))	// make sure all references to mobs/objs/turfs etc, are fully cut!
 					save_var = FALSE
 					continue
 
@@ -227,6 +227,9 @@
 
 
 /datum/map_object/proc/unpack_object_data(obj/O, obj/containing_obj)
+	if(!O || QDELETED(O))
+		return
+
 	O.x = x
 	O.y = y
 	O.z = z
@@ -234,7 +237,7 @@
 	if(containing_obj)
 		O.forceMove(containing_obj)
 
-	if(!O.initialized)
+	if(!O.initialized && !QDELETED(O))
 		O.initialize()
 
 	clearlist(O.contents)

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -109,7 +109,7 @@
 
 /obj/item/organ/internal/mmi_holder/robot/update_from_mmi()
 	..()
-	if(!stored_mmi | !stored_mmi.brainmob)
+	if(!stored_mmi || !stored_mmi.brainmob || !owner)
 		return
 	stored_mmi.icon_state = "mainboard"
 	icon_state = stored_mmi.icon_state

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -19,6 +19,13 @@
 	drop_sound = 'sound/items/drop/paper.ogg'
 	var/age = 0
 
+/obj/item/weapon/paper_bundle/on_persistence_load()
+	//regenerates pages
+	for(var/obj/O in src)
+		pages.Add(O)
+
+	update_icon()
+
 /obj/item/weapon/paper_bundle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -198,7 +198,10 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["stationtime"] = stationtime2text()
 		s["roundduration"] = roundduration2text()
 		s["stationname"] = station_name()
-		s["round_type"] = capitalize(ticker.mode.name)
+		if(ticker && ticker.mode)
+			s["round_type"] = capitalize(ticker.mode.name)
+		else
+			s["round_type"] = "No Data"
 		s["security_level"] = get_security_level()
 
 		if(input["status"] == "2")


### PR DESCRIPTION
* Fixes Modular Signs not affixing to buildings
* Fixes Status Displays for business not alt-clicking.
* Makes surgery tools be named differently so bounties can be clearer.
* Accounts DB no longer runtimes (apparently this causes 50% of the lag. oops)
* World Map Saver now saves paths to things.
* Paper bundles now save correctly.
* MMI runtimes upon load now corrected.
* xenoarch finds saving now does not runtime and cause epic lot load freezes.
