### PR TITLE
Diagonal barricade cleave exploit fix

### DIFF
--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -39,6 +39,8 @@
 			continue
 		if(!SA.Adjacent(user) || !SA.Adjacent(target)) // Cleaving only hits mobs near the target mob and user.
 			continue
+		if(!attack_can_reach(user, SM, 1))
+			continue
 		if(resolve_attackby(SA, user)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++
 

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -39,7 +39,7 @@
 			continue
 		if(!SA.Adjacent(user) || !SA.Adjacent(target)) // Cleaving only hits mobs near the target mob and user.
 			continue
-		if(!attack_can_reach(user, SM, 1))
+		if(!attack_can_reach(user, SA, 1))
 			continue
 		if(resolve_attackby(SA, user)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++


### PR DESCRIPTION
"Fixes the cleave attack being able to diagonally hit unreachable mobs through blocked turfs."

Ported from Polaris. https://github.com/PolarisSS13/Polaris/pull/7684