### PR TITLE
Redemption Boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/redemption_box.dm
+++ b/code/game/objects/items/weapons/storage/redemption_box.dm
@@ -1,13 +1,24 @@
 /obj/item/weapon/redemption_box
 	name = "redemption box"
-	desc = "A secure electronic box that can hold a large number of items that are released upon swiping your card to paying for the contents, \
-	it is powered by bluespace technology and virtually unbreakable."
+	desc = "A secure electronic box that can hold a large number of items that are released upon swiping your card to paying for the contents. \
+	It is powered by Bluespace technology and virtually unbreakable. Used to prevent fraud."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "redemption_box"
 	w_class = ITEMSIZE_LARGE
-
-	var/recieving_department = DEPT_NANOTRASEN
+	var/receiving_department = DEPT_NANOTRASEN
 	var/manufacture_comment = "Purchased from Nanotrasen"
 
 	var/list/starting_contents = list()	// we can put starting contents in this, for customisation.
+
+/obj/item/weapon/redemption_box/New()
+	..()
+
+	if(LAZYLEN(starting_contents))
+		for(var/V in starting_contents)
+			if(!ispath(V))
+				continue
+
+			new V( src )
 
 
 /obj/item/weapon/redemption_box/get_item_cost()
@@ -17,12 +28,17 @@
 	return price
 
 /obj/item/weapon/redemption_box/proc/unlock_box()
-	visible_message("<span class='notice'><b>[src]</b> beeps, \"Unlocking...Now extracting contents.\"</span>")
+	visible_message(span("notice", "<b>[src]</b> beeps, \"Unlocking...Now extracting contents.\""))
 	playsound(src, 'sound/machines/chime.ogg', 25)
 	for(var/obj/O in get_saveable_contents())
 		O.forceMove(get_turf(src))
 
 	qdel(src)
+
+/obj/item/weapon/redemption_box/examine(mob/user)
+	..()
+	if(get_item_cost())
+		to_chat(user, "Redemption Cost: <b>[get_item_cost()]CR</b>")
 
 /obj/item/weapon/redemption_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
@@ -35,16 +51,16 @@
 	var/obj/item/weapon/card/id/I = W.GetID()
 
 	if (!istype(W, /obj/item/weapon/card/id))
-		to_chat(user, "<span class='warning'>You need to scan your ID in order to pay for this item.</span>")
+		to_chat(user, span("warning", "You need to scan your ID in order to pay for this item."))
 		return
 
 	var/datum/money_account/customer_account = get_account(I.associated_account_number)
 	if(!customer_account)
-		visible_message("<span class='notice'>Error: Unable to access bank account details from this card, please try again.</span>")
+		visible_message(span("warning", "Error: Unable to access bank account details from this card, please try again."))
 		return
 
 	if(customer_account.suspended)
-		visible_message("<span class='notice'>Unable to access account: account suspended.</span>")
+		visible_message(span("notice", "Unable to access account: account suspended."))
 		return
 
 	// Have the customer punch in the PIN before checking if there's enough money. Prevents people from figuring out acct is
@@ -58,14 +74,16 @@
 			return
 
 	if(price > customer_account.money)
-		visible_message("Insufficient funds in account.")
+		visible_message(span("warning", "Insufficient funds in account."))
 		return
 
 	// debit money from the purchaser's account
 	charge_to_account(customer_account.account_number, "Redemption Box", "Purchase ([manufacture_comment])", "[src]", -price)
 
-	var/datum/department/department = dept_by_id(recieving_department)
+	var/datum/department/department = dept_by_id(receiving_department)
 
 	if(department)
 		department.adjust_funds(price, "Redemption Box: Purchase ([manufacture_comment])")
 
+	unlock_box()
+	return

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -424,7 +424,6 @@ var/list/name_to_material
 /material/plasteel/titanium
 	name = "titanium"
 	stack_type = /obj/item/stack/material/titanium
-	stack_type = null
 	conductivity = 2.38
 	icon_base = "metal"
 	door_icon_base = "metal"

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -99,7 +99,7 @@
 	material = "bauxite"
 
 /obj/item/weapon/ore/rutile
-	name = "rutile"
+	name = "raw rutile"
 	icon_state = "ore_rutile"
 	material = "rutile"
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -32,6 +32,10 @@ other types of metals and chemistry for reagents).
 	var/category = null 			//Primarily used for Mech Fabricators, but can be used for anything.
 	var/sort_string = "ZZZZZ"		//Sorting order
 
+	//Redemption box vars
+	var/protected = 0 				//If true, spawns in a redemption box
+	var/price = 100					//The price of the item
+
 /datum/design/New()
 	..()
 	item_name = name
@@ -100,6 +104,7 @@ other types of metals and chemistry for reagents).
 	materials = list("plastic" = 50, "aluminium" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
 	sort_string = "CAAAA"
+	price = 50
 
 /datum/design/item/stock_part/adv_capacitor
 	id = "adv_capacitor"
@@ -107,6 +112,7 @@ other types of metals and chemistry for reagents).
 	materials = list("plastic" = 50, "aluminium", "silver" = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 	sort_string = "CAAAB"
+	price = 100
 
 /datum/design/item/stock_part/super_capacitor
 	id = "super_capacitor"
@@ -114,6 +120,7 @@ other types of metals and chemistry for reagents).
 	materials = list("plastic" = 50, "aluminium" = 50, "gold" = 20)
 	build_path = /obj/item/weapon/stock_parts/capacitor/super
 	sort_string = "CAAAC"
+	price = 250
 
 /datum/design/item/stock_part/micro_mani
 	id = "micro_mani"
@@ -121,6 +128,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 30, "copper" = 10, "aluminium" = 10)
 	build_path = /obj/item/weapon/stock_parts/manipulator
 	sort_string = "CAABA"
+	price = 50
 
 /datum/design/item/stock_part/nano_mani
 	id = "nano_mani"
@@ -128,6 +136,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 30, "copper" = 10, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano
 	sort_string = "CAABB"
+	price = 100
 
 /datum/design/item/stock_part/pico_mani
 	id = "pico_mani"
@@ -135,6 +144,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 30, "silver" = 10, "gold" = 10)
 	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 	sort_string = "CAABC"
+	price = 250
 
 /datum/design/item/stock_part/basic_matter_bin
 	id = "basic_matter_bin"
@@ -142,6 +152,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 80, "aluminium" = 30)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
 	sort_string = "CAACA"
+	price = 50
 
 /datum/design/item/stock_part/adv_matter_bin
 	id = "adv_matter_bin"
@@ -149,6 +160,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 80, "aluminium" = 30, "copper" = 10)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/adv
 	sort_string = "CAACB"
+	price = 100
 
 /datum/design/item/stock_part/super_matter_bin
 	id = "super_matter_bin"
@@ -156,6 +168,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 80, "aluminium" = 50, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 	sort_string = "CAACC"
+	price = 250
 
 /datum/design/item/stock_part/basic_micro_laser
 	id = "basic_micro_laser"
@@ -163,6 +176,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
 	sort_string = "CAADA"
+	price = 50
 
 /datum/design/item/stock_part/high_micro_laser
 	id = "high_micro_laser"
@@ -170,6 +184,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high
 	sort_string = "CAADB"
+	price = 100
 
 /datum/design/item/stock_part/ultra_micro_laser
 	id = "ultra_micro_laser"
@@ -177,6 +192,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "glass" = 10, "diamond" = 10)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 	sort_string = "CAADC"
+	price = 250
 
 /datum/design/item/stock_part/basic_sensor
 	id = "basic_sensor"
@@ -184,6 +200,7 @@ other types of metals and chemistry for reagents).
 	materials = list("aluminium" = 50, "glass" = 20, "copper" = 10)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
 	sort_string = "CAAEA"
+	price = 50
 
 /datum/design/item/stock_part/adv_sensor
 	id = "adv_sensor"
@@ -191,6 +208,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 	sort_string = "CAAEB"
+	price = 100
 
 /datum/design/item/stock_part/phasic_sensor
 	id = "phasic_sensor"
@@ -198,6 +216,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 20, "gold" = 10)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 	sort_string = "CAAEC"
+	price = 250
 
 /datum/design/item/stock_part/RPED
 	name = "Rapid Part Exchange Device"
@@ -207,6 +226,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 5000, "copper" = 500)
 	build_path = /obj/item/weapon/storage/part_replacer
 	sort_string = "CBAAA"
+	price = 500
 
 /datum/design/item/powercell
 	build_type = PROTOLATHE | MECHFAB
@@ -233,6 +253,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell
 	category = "Misc"
 	sort_string = "DAAAA"
+	price = 100
 
 /datum/design/item/powercell/high
 	name = "high-capacity"
@@ -243,6 +264,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell/high
 	category = "Misc"
 	sort_string = "DAAAB"
+	price = 150
 
 /datum/design/item/powercell/super
 	name = "super-capacity"
@@ -252,6 +274,8 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell/super
 	category = "Misc"
 	sort_string = "DAAAC"
+	protected = TRUE
+	price = 200
 
 /datum/design/item/powercell/hyper
 	name = "hyper-capacity"
@@ -261,6 +285,8 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell/hyper
 	category = "Misc"
 	sort_string = "DAAAD"
+	protected = TRUE
+	price = 250
 
 /datum/design/item/powercell/device
 	name = "device"
@@ -270,6 +296,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell/device
 	category = "Misc"
 	sort_string = "DAABA"
+	price = 100
 
 /datum/design/item/powercell/weapon
 	name = "weapon"
@@ -279,9 +306,11 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/cell/device/weapon
 	category = "Misc"
 	sort_string = "DAABB"
+	price = 150
 
 /datum/design/item/hud
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, "copper" = 100)
+	price = 250
 
 /datum/design/item/hud/AssembleDesignName()
 	..()
@@ -323,6 +352,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "silver" = 500)
 	build_path = /obj/item/weapon/pickaxe/jackhammer
 	sort_string = "KAAAA"
+	price = 325
 
 /datum/design/item/weapon/mining/drill
 	id = "drill"
@@ -330,6 +360,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1000, "copper" = 150) //expensive, but no need for miners.
 	build_path = /obj/item/weapon/pickaxe/drill
 	sort_string = "KAAAB"
+	price = 200
 
 /datum/design/item/weapon/mining/plasmacutter
 	id = "plasmacutter"
@@ -337,6 +368,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1500, "glass" = 500, "gold" = 500, "phoron" = 500)
 	build_path = /obj/item/weapon/pickaxe/plasmacutter
 	sort_string = "KAAAC"
+	price = 400
 
 /datum/design/item/weapon/mining/pick_diamond
 	id = "pick_diamond"
@@ -344,6 +376,8 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1500, "diamond" = 3000)
 	build_path = /obj/item/weapon/pickaxe/diamond
 	sort_string = "KAAAD"
+	protected = TRUE
+	price = 650
 
 /datum/design/item/weapon/mining/drill_diamond
 	id = "drill_diamond"
@@ -351,6 +385,9 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000, "diamond" = 2000, "copper" = 300, "silver" = 150)
 	build_path = /obj/item/weapon/pickaxe/diamonddrill
 	sort_string = "KAAAE"
+	protected = TRUE
+	price = 800
+
 
 /datum/design/item/device/depth_scanner
 	desc = "Used to check spatial depth and density of rock outcroppings."
@@ -359,6 +396,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1000,"glass" = 1000, "copper" = 100)
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "KAAAF"
+	price = 100
 
 ///////////////////////////////////
 /////////Shield Generators/////////
@@ -381,6 +419,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200, "copper" = 50)
 	build_path = /obj/item/device/robotanalyzer
 	sort_string = "MACFA"
+	price = 150
 
 /datum/design/item/medical/mass_spectrometer
 	desc = "A device for analyzing chemicals in blood."
@@ -388,6 +427,7 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/device/mass_spectrometer
 	sort_string = "MACAA"
+	price = 100
 
 /datum/design/item/medical/adv_mass_spectrometer
 	desc = "A device for analyzing chemicals in blood and their quantities."
@@ -396,6 +436,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200, "copper" = 100)
 	build_path = /obj/item/device/mass_spectrometer/adv
 	sort_string = "MACAB"
+	price = 200
 
 /datum/design/item/medical/reagent_scanner
 	desc = "A device for identifying chemicals."
@@ -403,6 +444,7 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/device/reagent_scanner
 	sort_string = "MACBA"
+	price = 150
 
 /datum/design/item/medical/adv_reagent_scanner
 	desc = "A device for identifying chemicals and their proportions."
@@ -411,6 +453,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200, "copper" = 100)
 	build_path = /obj/item/device/reagent_scanner/adv
 	sort_string = "MACBB"
+	price = 200
 
 /datum/design/item/beaker/AssembleDesignName()
 	name = "Beaker prototype ([item_name])"
@@ -423,6 +466,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "silver" = 100, "copper" = 100)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	sort_string = "MADAA"
+	price = 250
 
 /datum/design/item/beaker/bluespace
 	name = TECH_BLUESPACE
@@ -432,6 +476,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "phoron" = 3000, "diamond" = 500)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	sort_string = "MADAB"
+	price = 500
 
 /datum/design/item/medical/nanopaste
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
@@ -440,6 +485,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 7000, "silver" = 300)
 	build_path = /obj/item/stack/nanopaste
 	sort_string = "MBAAA"
+	price = 75
 
 /datum/design/item/medical/scalpel_laser1
 	name = "Basic Laser Scalpel"
@@ -449,6 +495,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "copper" = 2500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser1
 	sort_string = "MBBAA"
+	price = 100
 
 /datum/design/item/medical/scalpel_laser2
 	name = "Improved Laser Scalpel"
@@ -458,6 +505,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser2
 	sort_string = "MBBAB"
+	price = 150
 
 /datum/design/item/medical/scalpel_laser3
 	name = "Advanced Laser Scalpel"
@@ -467,6 +515,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2000, "gold" = 1500)
 	build_path = /obj/item/weapon/surgical/scalpel/laser3
 	sort_string = "MBBAC"
+	price = 200
 
 /datum/design/item/medical/scalpel_manager
 	name = "Incision Management System"
@@ -476,6 +525,7 @@ other types of metals and chemistry for reagents).
 	materials = list (DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 1500, "gold" = 1500, "diamond" = 750, "copper" = 500)
 	build_path = /obj/item/weapon/surgical/scalpel/manager
 	sort_string = "MBBAD"
+	price = 300
 
 /datum/design/item/medical/bone_clamp
 	name = "Bone Clamp"
@@ -485,6 +535,7 @@ other types of metals and chemistry for reagents).
 	materials = list (DEFAULT_WALL_MATERIAL = 12500, "glass" = 7500, "silver" = 2500, "copper" = 500, "plastic" = 500)
 	build_path = /obj/item/weapon/surgical/bone_clamp
 	sort_string = "MBBAE"
+	price = 300
 
 /datum/design/item/medical/advanced_roller
 	name = "advanced roller bed"
@@ -494,6 +545,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 2000, "phoron" = 2000, "plastic" = 1000)
 	build_path = /obj/item/roller/adv
 	sort_string = "MBBAF"
+	price = 150
 
 /datum/design/item/medical/improved_analyzer
 	name = "improved health analyzer"
@@ -503,6 +555,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1000, "gold" = 1500, "copper" = 1000)
 	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "MBBAG"
+	price = 200
 
 /datum/design/item/implant
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50, "plastic" = 50)
@@ -517,6 +570,7 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/weapon/implantcase/chem
 	sort_string = "MFAAA"
+	price = 200
 
 /datum/design/item/implant/freedom
 	name = "freedom"
@@ -524,10 +578,13 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_ILLEGAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/weapon/implantcase/freedom
 	sort_string = "MFAAB"
+	protected = TRUE
+	price = 500
 
 /datum/design/item/weapon/AssembleDesignName()
 	..()
 	name = "Weapon prototype ([item_name])"
+	protected = TRUE
 
 /datum/design/item/weapon/AssembleDesignDesc()
 	if(!desc)
@@ -542,6 +599,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "iron" = 500, "plastic" = 500)
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	sort_string = "TAAAA"
+	price = 3500
 
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
@@ -549,6 +607,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 500, "copper" = 500)
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	sort_string = "TAAAB"
+	price = 20000
 
 /datum/design/item/weapon/lasercannon
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
@@ -557,6 +616,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1000, "diamond" = 2000, "silver" = 500)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "TAAAC"
+	price = 7000
 
 /datum/design/item/weapon/phoronpistol
 	id = "ppistol"
@@ -564,6 +624,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "phoron" = 3000)
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "TAAAD"
+	price = 6000
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
@@ -572,6 +633,7 @@ other types of metals and chemistry for reagents).
 	chemicals = list("mutagen" = 40)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
+	price = 10000
 
 /datum/design/item/weapon/smg
 	id = "smg"
@@ -579,6 +641,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 2000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/projectile/automatic
 	sort_string = "TAABA"
+	price = 7500
 
 /datum/design/item/weapon/ammo_9mm
 	id = "ammo_9mm"
@@ -586,6 +649,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3750, "silver" = 100, "copper" = 2750)
 	build_path = /obj/item/ammo_magazine/box/c9mm
 	sort_string = "TAACA"
+	price = 100
 
 /datum/design/item/weapon/stunshell
 	desc = "A stunning shell for a shotgun."
@@ -594,6 +658,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "plastic" = 500, "copper" = 100)
 	build_path = /obj/item/ammo_casing/a12g/stunshell
 	sort_string = "TAACB"
+	price = 100
 
 /datum/design/item/weapon/chemsprayer
 	desc = "An advanced chem spraying device."
@@ -602,6 +667,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "copper" = 1000)
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 	sort_string = "TABAA"
+	price = 2500
 
 /datum/design/item/weapon/rapidsyringe
 	id = "rapidsyringe"
@@ -609,6 +675,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
 	build_path = /obj/item/weapon/gun/launcher/syringe/rapid
 	sort_string = "TABAB"
+	price = 2500
 
 /datum/design/item/weapon/temp_gun
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
@@ -617,6 +684,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 500, "silver" = 3000)
 	build_path = /obj/item/weapon/gun/energy/temperature
 	sort_string = "TABAC"
+	price = 10000
 
 /datum/design/item/weapon/large_grenade
 	id = "large_Grenade"
@@ -624,6 +692,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 3000)
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
 	sort_string = "TACAA"
+	price = 2000
 
 /datum/design/item/weapon/dartgun
 	desc = "A gun that fires small hollow chemical-payload darts."
@@ -632,6 +701,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "gold" = 5000, "silver" = 2500, "glass" = 750)
 	build_path = /obj/item/weapon/gun/projectile/dartgun/research
 	sort_string = "TACAB"
+	price = 4000
 
 /datum/design/item/weapon/dartgunmag_small
 	id = "dartgun_mag_s"
@@ -639,6 +709,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 300, "gold" = 100, "silver" = 100, "glass" = 300, "plastic" = 100)
 	build_path = /obj/item/ammo_magazine/chemdart/small
 	sort_string = "TACAC"
+	price = 300
 
 /datum/design/item/weapon/dartgun_ammo_small
 	id = "dartgun_ammo_s"
@@ -646,6 +717,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "gold" = 30, "silver" = 30, "glass" = 50, "plastic" = 50)
 	build_path = /obj/item/ammo_casing/chemdart/small
 	sort_string = "TACAD"
+	price = 50
 
 /datum/design/item/weapon/dartgunmag_med
 	id = "dartgun_mag_m"
@@ -653,6 +725,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "gold" = 150, "silver" = 150, "diamond" = 200, "glass" = 400, "plastic" = 200)
 	build_path = /obj/item/ammo_magazine/chemdart
 	sort_string = "TACAE"
+	price = 600
 
 /datum/design/item/weapon/dartgun_ammo_med
 	id = "dartgun_ammo_m"
@@ -660,6 +733,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 80, "gold" = 40, "silver" = 40, "glass" = 60, "plastic" = 60)
 	build_path = /obj/item/ammo_casing/chemdart
 	sort_string = "TACAF"
+	price = 100
 
 /datum/design/item/weapon/fuelrod
 	id = "fuelrod_gun"
@@ -667,6 +741,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "gold" = 500, "silver" = 500, "uranium" = 1000, "phoron" = 3000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/magnetic/fuelrod
 	sort_string = "TACBA"
+	price = 50000
 
 /datum/design/item/weapon/flora_gun
 	id = "flora_gun"
@@ -674,6 +749,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 500, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/floragun
 	sort_string = "TBAAA"
+	price = 3000
 
 /datum/design/item/weapon/slimebation
 	id = "slimebation"
@@ -681,6 +757,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000)
 	build_path = /obj/item/weapon/melee/baton/slime
 	sort_string = "TBAAB"
+	price = 1000
 
 /datum/design/item/weapon/slimetaser
 	id = "slimetaser"
@@ -688,6 +765,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "copper" = 1000, "plastic" = 100)
 	build_path = /obj/item/weapon/gun/energy/taser/xeno
 	sort_string = "TBAAC"
+	price = 2500
 
 /datum/design/item/stock_part/subspace_ansible
 	id = "s-ansible"
@@ -695,6 +773,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 80, "silver" = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/ansible
 	sort_string = "UAAAA"
+	price = 500
 
 /datum/design/item/stock_part/hyperwave_filter
 	id = "s-filter"
@@ -702,6 +781,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 40, "silver" = 10)
 	build_path = /obj/item/weapon/stock_parts/subspace/sub_filter
 	sort_string = "UAAAB"
+	price =  500
 
 /datum/design/item/stock_part/subspace_amplifier
 	id = "s-amplifier"
@@ -709,6 +789,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "gold" = 30, "uranium" = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/amplifier
 	sort_string = "UAAAC"
+	price = 500
 
 /datum/design/item/stock_part/subspace_treatment
 	id = "s-treatment"
@@ -716,6 +797,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "silver" = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/treatment
 	sort_string = "UAAAD"
+	price = 500
 
 /datum/design/item/stock_part/subspace_analyzer
 	id = "s-analyzer"
@@ -723,6 +805,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10, "gold" = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/analyzer
 	sort_string = "UAAAE"
+	price = 500
 
 /datum/design/item/stock_part/subspace_crystal
 	id = "s-crystal"
@@ -730,6 +813,7 @@ other types of metals and chemistry for reagents).
 	materials = list("glass" = 1000, "silver" = 20, "gold" = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/crystal
 	sort_string = "UAAAF"
+	price = 500
 
 /datum/design/item/stock_part/subspace_transmitter
 	id = "s-transmitter"
@@ -737,6 +821,7 @@ other types of metals and chemistry for reagents).
 	materials = list("glass" = 100, "silver" = 10, "uranium" = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/transmitter
 	sort_string = "UAAAG"
+	price = 500
 
 /datum/design/item/device/ano_scanner
 	name = "Alden-Saraspova counter"
@@ -746,6 +831,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10000,"glass" = 5000, "copper" = 2000)
 	build_path = /obj/item/device/ano_scanner
 	sort_string = "UAAAH"
+	price = 250
 
 /datum/design/item/light_replacer
 	name = "Light replacer"
@@ -755,6 +841,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1500, "silver" = 150, "glass" = 3000, "copper" = 100)
 	build_path = /obj/item/device/lightreplacer
 	sort_string = "VAAAH"
+	price = 100
 
 /datum/design/item/paicard
 	name = "'pAI', personal artificial intelligence device"
@@ -763,6 +850,7 @@ other types of metals and chemistry for reagents).
 	materials = list("glass" = 500, DEFAULT_WALL_MATERIAL = 500, "copper" = 150, "aluminium" = 250)
 	build_path = /obj/item/device/paicard
 	sort_string = "VABAI"
+	price = 200
 
 /datum/design/item/communicator
 	name = "Communicator"
@@ -771,6 +859,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 500, "copper" = 100, "aluminium" = 250)
 	build_path = /obj/item/device/communicator
 	sort_string = "VABAJ"
+	price = 100
 
 /datum/design/item/intellicard
 	name = "'intelliCore', AI preservation and transportation system"
@@ -780,6 +869,7 @@ other types of metals and chemistry for reagents).
 	materials = list("glass" = 1000, "gold" = 200, "silver" = 150, "copper" = 100, "aluminium" = 100)
 	build_path = /obj/item/device/aicard
 	sort_string = "VACAA"
+	price = 700
 
 /datum/design/item/dronebrain
 	name = "Robotic intelligence circuit"
@@ -790,6 +880,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/mmi/digital/robot
 	category = "Misc"
 	sort_string = "VACAC"
+	price = 3000
 
 /datum/design/item/posibrain
 	name = "Positronic brain"
@@ -800,6 +891,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/mmi/digital/posibrain
 	category = "Misc"
 	sort_string = "VACAB"
+	price = 5000
 
 /datum/design/item/mmi
 	name = "Man-machine interface"
@@ -810,6 +902,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/mmi
 	category = "Misc"
 	sort_string = "VACBA"
+	price = 1500
 
 /datum/design/item/beacon
 	name = "Bluespace tracking beacon design"
@@ -818,6 +911,7 @@ other types of metals and chemistry for reagents).
 	materials = list (DEFAULT_WALL_MATERIAL = 20, "glass" = 10, "copper" = 10)
 	build_path = /obj/item/device/radio/beacon
 	sort_string = "VADAA"
+	price = 500
 
 /datum/design/item/gps
 	name = "Triangulating device design"
@@ -827,6 +921,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "copper" = 250)
 	build_path = /obj/item/device/gps
 	sort_string = "VADAB"
+	price = 300
 
 /datum/design/item/beacon_locator
 	name = "Beacon tracking pinpointer"
@@ -836,6 +931,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 500, "copper" = 250)
 	build_path = /obj/item/device/beacon_locator
 	sort_string = "VADAC"
+	price = 300
 
 /datum/design/item/bag_holding
 	name = "'Bag of Holding', an infinite capacity bag prototype"
@@ -845,6 +941,8 @@ other types of metals and chemistry for reagents).
 	materials = list("gold" = 3000, "diamond" = 1500, "uranium" = 250)
 	build_path = /obj/item/weapon/storage/backpack/holding
 	sort_string = "VAEAA"
+	protected = TRUE
+	price = 5000
 
 /datum/design/item/binaryencrypt
 	name = "Binary encryption key"
@@ -854,6 +952,8 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300, "copper" = 300)
 	build_path = /obj/item/device/encryptionkey/binary
 	sort_string = "VASAA"
+	protected = TRUE
+	price = 500
 
 /datum/design/item/chameleon
 	name = "Holographic equipment kit"
@@ -863,6 +963,8 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "copper" = 250, "silver" = 500, "gold" = 500)
 	build_path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	sort_string = "VASBA"
+	protected = TRUE
+	price = 2500
 
 /datum/design/item/experimental_welder
 	name = "Experimental welding tool"
@@ -872,6 +974,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 70, "glass" = 120, "phoron" = 100, "copper" = 100, "aluminium" = 100)
 	build_path = /obj/item/weapon/weldingtool/experimental
 	sort_string = "VASCA"
+	price =  350
 
 /datum/design/item/hand_drill
 	name = "Hand drill"
@@ -881,6 +984,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100, "aluminium" = 100, "copper" = 100)
 	build_path = /obj/item/weapon/screwdriver/power
 	sort_string = "VASDA"
+	price = 300
 
 /datum/design/item/jaws_life
 	name = "Jaws of life"
@@ -890,6 +994,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 300, "silver" = 100, "copper" = 100, "aluminium" = 100)
 	build_path = /obj/item/weapon/crowbar/power
 	sort_string = "VASEA"
+	price = 350
 
 /datum/design/item/device/t_scanner_upg
 	name = "Upgraded T-ray Scanner"
@@ -899,7 +1004,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 500, "phoron" = 150, "copper" = 100)
 	build_path = /obj/item/device/t_scanner/upgraded
 	sort_string = "VASSA"
-
+	price = 275
 
 /datum/design/item/device/t_scanner_adv
 	name = "Advanced T-ray Scanner"
@@ -909,6 +1014,8 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 1250, "phoron" = 500, "silver" = 50, "copper" = 250)
 	build_path = /obj/item/device/t_scanner/advanced
 	sort_string = "VASSB"
+	price = 350
+
 /*
 CIRCUITS BELOW
 */
@@ -1328,6 +1435,7 @@ CIRCUITS BELOW
 
 /datum/design/circuit/mecha
 	req_tech = list(TECH_DATA = 3)
+	protected = TRUE
 
 /datum/design/circuit/mecha/AssembleDesignName()
 	name = "Exosuit module circuit design ([name])"
@@ -1339,12 +1447,14 @@ CIRCUITS BELOW
 	id = "ripley_main"
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
 	sort_string = "NAAAA"
+	price = 750
 
 /datum/design/circuit/mecha/ripley_peri
 	name = "APLU 'Ripley' peripherals control"
 	id = "ripley_peri"
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 	sort_string = "NAAAB"
+	price = 750
 
 /datum/design/circuit/mecha/odysseus_main
 	name = "'Odysseus' central control"
@@ -1352,6 +1462,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 3,TECH_BIO = 2)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/main
 	sort_string = "NAABA"
+	price = 900
 
 /datum/design/circuit/mecha/odysseus_peri
 	name = "'Odysseus' peripherals control"
@@ -1359,6 +1470,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 3,TECH_BIO = 2)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
 	sort_string = "NAABB"
+	price = 900
 
 /datum/design/circuit/mecha/gygax_main
 	name = "'Gygax' central control"
@@ -1366,6 +1478,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/main
 	sort_string = "NAACA"
+	price = 1500
 
 /datum/design/circuit/mecha/gygax_peri
 	name = "'Gygax' peripherals control"
@@ -1373,6 +1486,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/peripherals
 	sort_string = "NAACB"
+	price = 1500
 
 /datum/design/circuit/mecha/gygax_targ
 	name = "'Gygax' weapon control and targeting"
@@ -1380,6 +1494,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4, TECH_COMBAT = 2)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/targeting
 	sort_string = "NAACC"
+	price = 1500
 
 /datum/design/circuit/mecha/durand_main
 	name = "'Durand' central control"
@@ -1387,6 +1502,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
 	sort_string = "NAADA"
+	price = 5000
 
 /datum/design/circuit/mecha/durand_peri
 	name = "'Durand' peripherals control"
@@ -1394,6 +1510,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
 	sort_string = "NAADB"
+	price = 5000
 
 /datum/design/circuit/mecha/durand_targ
 	name = "'Durand' weapon control and targeting"
@@ -1401,6 +1518,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4, TECH_COMBAT = 2)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
 	sort_string = "NAADC"
+	price = 5000
 
 /datum/design/circuit/tcom
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
@@ -1498,10 +1616,14 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4, TECH_BIO = 3)
 	build_path = /obj/item/weapon/circuitboard/aicore
 	sort_string = "XAAAA"
+	protected = TRUE
+	price = 10000
 
 /datum/design/aimodule
 	build_type = IMPRINTER
 	materials = list("glass" = 2000, "gold" = 100, "copper" = 500)
+	protected = TRUE
+	price = 3500
 
 /datum/design/aimodule/AssembleDesignName()
 	name = "AI module design ([name])"

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -197,8 +197,16 @@
 		reagents.remove_reagent(C, D.chemicals[C] * mat_efficiency)
 
 	if(D.build_path)
-		var/obj/new_item = D.Fabricate(src, src)
-		new_item.loc = loc
+		var/obj/item/new_item = D.Fabricate(src, src)
+		new_item.tagged_price = D.price
+		if(D.protected)
+			var/obj/item/weapon/redemption_box/r_box = new /obj/item/weapon/redemption_box(loc)
+			r_box.receiving_department = DEPT_RESEARCH
+			if(LAZYLEN(new_item.origin_tech))
+				r_box.origin_tech = new_item.origin_tech
+			new_item.forceMove(r_box)
+		else
+			new_item.loc = loc
 		if(mat_efficiency != 1) // No matter out of nowhere
 			if(new_item.matter && new_item.matter.len > 0)
 				for(var/i in new_item.matter)
@@ -227,6 +235,14 @@
 			mattype = /obj/item/stack/material/phoron
 		if("uranium")
 			mattype = /obj/item/stack/material/uranium
+		if("copper")
+			mattype = /obj/item/stack/material/copper
+		if("aluminium")
+			mattype = /obj/item/stack/material/aluminium
+		if("void opal")
+			mattype = /obj/item/stack/material/void_opal
+		if("titanium")
+			mattype = /obj/item/stack/material/titanium
 		else
 			return
 	var/obj/item/stack/material/S = new mattype(loc)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -66,6 +66,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			return_name = "Uranium"
 		if("diamond")
 			return_name = "Diamond"
+		if("copper")
+			return_name = "Copper"
+		if("aluminium")
+			return_name = "Aluminium"
+		if("void opal")
+			return_name = "Void Opal"
+		if("titanium")
+			return_name = "Titanium"
 	return return_name
 
 /obj/machinery/computer/rdconsole/proc/CallReagentName(var/ID)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -36,6 +36,14 @@
 			return /obj/item/stack/material/uranium
 		if("diamond")
 			return /obj/item/stack/material/diamond
+		if("copper")
+			return /obj/item/stack/material/copper
+		if("aluminium")
+			return /obj/item/stack/material/aluminium
+		if("void opal")
+			return /obj/item/stack/material/void_opal
+		if("titanium")
+			return /obj/item/stack/material/titanium
 	return null
 
 /obj/machinery/r_n_d/proc/getMaterialName(var/type)
@@ -58,6 +66,14 @@
 			return "uranium"
 		if(/obj/item/stack/material/diamond)
 			return "diamond"
+		if(/obj/item/stack/material/copper)
+			return "copper"
+		if(/obj/item/stack/material/aluminium)
+			return "aluminium"
+		if(/obj/item/stack/material/void_opal)
+			return "void opal"
+		if(/obj/item/stack/material/titanium)
+			return "titanium"
 
 /obj/machinery/r_n_d/proc/eject(var/material, var/amount)
 	if(!(material in materials))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds redemption boxes.

**New Features**
 - Adds redemption boxes. Redemption boxes are printed on high-risk items and can only be opened after payment. Research boxes also inherit the origin tech of the item inside. 

**Bug Fixes**
 - New materials can finally be ejected from research equipment.
 - **Actually fixed titanium.** Must've slipped in that null line in previous PR. My bad.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lowpop research stealing potentially fixed?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Redemption boxes added to the game
fix: Materials can be ejected from research equipment once again
fix:: Titanium can be smelted once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->