### PR TITLE
Updates Jukebox & Plant Pots to be Above

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -33,7 +33,7 @@ datum/track/New(var/title_name, var/audio)
 	var/freq = 0
 
 	table_drag = TRUE
-	plane = MOB_PLANE
+	plane = ABOVE_MOB_PLANE
 
 	var/datum/track/current_track
 	var/list/datum/track/tracks = list(

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -164,7 +164,7 @@
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-01"
 
-	plane = MOB_PLANE
+	plane = ABOVE_MOB_PLANE
 
 	var/obj/item/stored_item
 	table_drag = TRUE

--- a/code/modules/economy/expense_manager.dm
+++ b/code/modules/economy/expense_manager.dm
@@ -29,6 +29,7 @@
 	var/current_operator = ""
 
 	dont_save = TRUE
+	table_drag = TRUE
 
 
 


### PR DESCRIPTION
Jukeboxes and plant pots now show over mob instead of under.

Sorts out a couple of table drag objects too.
