### PR TITLE
Fixes infinite loop on synth brain transplant

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -460,8 +460,8 @@
 		target.languages = M.brainmob.languages
 
 	spawn(0) //Name yourself on your own damn time
-		var/new_name = ""
-		while(!new_name)
+		var/new_name = target.real_name
+		while(target.client)
 			if(!target) return
 			var/try_name = input(target,"Pick a name for your new form!", "New Name", target.name)
 			var/clean_name = sanitizeName(try_name, allow_numbers = TRUE)
@@ -470,6 +470,7 @@
 				if(okay == "Ok")
 					new_name = clean_name
 
+		new_name = sanitizeName(new_name, allow_numbers = TRUE)
 		target.name = new_name
 		target.real_name = target.name
 


### PR DESCRIPTION
Also adds an extra sanitation to prevent a synth body wearing an ID (and thus getting "(as name)" slapped onto the display name) from breaking regex with rogue ()s by forcing the bad display name into the target's real_name var and trying to shove those "(as" and "name)" raw into the chat mention system.

Ported fix from Polaris. https://github.com/PolarisSS13/Polaris/pull/7460
