### PR TITLE
Fixes chairs acting as handcuffs

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -315,7 +315,7 @@
 /mob/living/carbon/can_use_hands()
 	if(handcuffed)
 		return 0
-	if(buckled && ! istype(buckled, /obj/structure/bed/chair)) // buckling does not restrict hands
+	if(buckled && istype(buckled, /obj/structure/bed/nest)) // buckling does not restrict hands
 		return 0
 	return 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1025,10 +1025,11 @@ default behaviour is:
 					pixel_y = V.mob_offset_y
 		else if(buckled)
 			anchored = 1
-			canmove = 0
+			canmove = 1 //The line above already makes the chair not swooce away if the sitter presses a button. No need to incapacitate them as a criminally large amount of mechanics read this var as a type of stun.
 			if(istype(buckled))
 				if(buckled.buckle_lying != -1)
 					lying = buckled.buckle_lying
+					canmove = buckled.buckle_movable
 				if(buckled.buckle_movable)
 					anchored = 0
 					canmove = 1


### PR DESCRIPTION
Fixes some utterly redundant and ancient broken spaghetti that had simply been shrugged off for at least 7 years.

-Fixes chairs not allowing people to use hands. Leaves an exception for the xeno nest, but apparently even that is redundant due to the fact that the victim is laid down on it. Same with all the beds, so this PR has no side effect of suddenly allowing self surgery and all that jazz.
-Also fixes chairs toggling the canmove var, which also was completely redundant, because a wheelchair specific var for allowing movement already exists and is utilized, and most chairs are anchored anyway. This was a fat issue because a criminally large amount of other unrelated mechanics have been using the canmove var as a type of STUN for some reason, including wack stuff such as the menu buttons for cartridge exclusive PDA features and much more. Also apparently most of the forementioned wack stuff already checks the actual incapacitation vars as well so canmove never really had business there in the first place.

Fix ported from polaris. https://github.com/PolarisSS13/Polaris/pull/6588
