### PR TITLE
Metal Detectors Nerf

### DIFF
--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -1,3 +1,13 @@
+GLOBAL_LIST_INIT(metal_detector_items, typecacheof(list(
+	/obj/item/weapon/gun,
+	/obj/item/weapon/material,
+	/obj/item/weapon/melee,
+	/obj/item/device/transfer_valve,
+	/obj/item/weapon/grenade,
+	/obj/item/ammo_casing,
+	/obj/item/ammo_magazine
+	)))
+
 /obj/machinery/metal_detector
 	name = "metal detector"
 	desc = "An advanced metal detector used to detect weapons."
@@ -59,8 +69,8 @@
 		return
 
 	var/list/items_to_check = M.GetAllContents()
-	for(var/obj/O in items_to_check)
-		if(O.is_contraband())
+	for(var/A in items_to_check)
+		if(is_type_in_typecache(A, GLOB.metal_detector_items))
 			trigger_alarm(M)
 			break
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Metal Detectors now only detect certain items, IE: guns, weapons, bombs, grenades, ammo.
## Why It's Good For The Game

Reduces false positives slightly, actually is a buff if you think about it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Limits the amount of things metal detectors can detect.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->