### PR TITLE
Remote button fix + Redemption Box Labels

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -10,7 +10,7 @@
 	idle_power_usage = 2
 	active_power_usage = 4
 
-	unique_save_vars = list("id", "active", "req_access", "req_one_accesss")
+	unique_save_vars = list("id", "active", "req_access", "req_one_access")
 
 /obj/machinery/button/attack_ai(mob/user as mob)
 	return attack_hand(user)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -204,6 +204,7 @@
 			r_box.receiving_department = DEPT_RESEARCH
 			if(LAZYLEN(new_item.origin_tech))
 				r_box.origin_tech = new_item.origin_tech
+				r_box.name += " ([new_item.name])"
 			new_item.forceMove(r_box)
 		else
 			new_item.loc = loc


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- req_one_access fixed on remote buttons
- Redemption box is now labelled with what item it contains

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more mystery boxes, actual access saving on buttons
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: remote buttons now save single access requirements
add: redemption boxes are now labelled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->