### PR TITLE
The Big Synth Employment Update

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -227,6 +227,13 @@
 #define MOB_PULL_SAME 2
 #define MOB_PULL_LARGER 3
 
+
+// SYNTH TYPES
+#define PREF_FBP_CYBORG "cyborg"
+#define PREF_FBP_POSI "posi"
+#define PREF_FBP_SOFTWARE "software"
+
+
 //XENOBIO2 FLAGS
 #define NOMUT		0
 #define COLORMUT 	1

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -84,6 +84,9 @@ SUBSYSTEM_DEF(jobs)
 			return 0
 		if((player.client.prefs.criminal_status == "Incarcerated") && job.title != "Prisoner")
 			return 0
+		if(player.client.prefs.is_synth() && !job.allows_synths)
+			return 0
+
 		var/position_limit = job.total_positions
 		if(!latejoin)
 			position_limit = job.spawn_positions
@@ -129,9 +132,16 @@ SUBSYSTEM_DEF(jobs)
 		if(flag && (!player.client.prefs.be_special & flag))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
+
+		if(player.client.prefs.is_synth() && !job.allows_synths)
+			Debug("FOC job does not allow synths, Player: [player]")
+			continue
+
 		if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
 			Debug("FOC pass, Player: [player], Level:[level]")
 			candidates += player
+
+
 
 	return candidates
 
@@ -165,6 +175,11 @@ SUBSYSTEM_DEF(jobs)
 		if(!is_hard_whitelisted(player, job))
 			Debug("GRJ not hard whitelisted failed, Player: [player]")
 			continue
+
+		if(player.client.prefs.is_synth() && !job.allows_synths)
+			Debug("GRJ job does not allow synths, Player: [player]")
+			continue
+
 		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 			Debug("GRJ Random job given, Player: [player], Job: [job]")
 			AssignRole(player, job.title)
@@ -318,6 +333,11 @@ SUBSYSTEM_DEF(jobs)
 				if((player.client.prefs.criminal_status == "Incarcerated") && job.title != "Prisoner") //CASSJUMP
 					Debug("DO player is prisoner, Player: [player], Job:[job.title]")
 					continue
+
+				if(player.client.prefs.is_synth() && !job.allows_synths)
+					Debug("DO job does not allow synths, Player: [player]")
+					continue
+
 				// If the player wants that job on this level, then try give it to him.
 				if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -12,6 +12,7 @@
 	minimum_character_age = 1
 	hide_on_manifest = 0
 	wage = 5 // Ha-ha poor people (tm)
+	synth_wage = 0 // no payment for you
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant

--- a/code/game/jobs/job/council.dm
+++ b/code/game/jobs/job/council.dm
@@ -20,7 +20,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 14
 	wage = 500
 
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	minimum_character_age = 30
 	ideal_character_age = 50
@@ -70,7 +70,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 10
 	wage = 350
 
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	minimum_character_age = 26
 	alt_titles = list("City Manager")

--- a/code/game/jobs/job/council.dm
+++ b/code/game/jobs/job/council.dm
@@ -20,6 +20,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 14
 	wage = 500
 
+	allow_synths = FALSE
+
 	minimum_character_age = 30
 	ideal_character_age = 50
 
@@ -68,6 +70,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 10
 	wage = 350
 
+	allow_synths = FALSE
 
 	minimum_character_age = 26
 	alt_titles = list("City Manager")
@@ -106,9 +109,10 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/secretary
 	wage = 100
+	synth_wage = 50
+
 	access = list(access_heads, access_hop, access_maint_tunnels, access_legal)
 	minimal_access = list(access_heads, access_hop, access_maint_tunnels, access_legal)
-
 
 	minimum_character_age = 20
 
@@ -134,6 +138,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	idtype = /obj/item/weapon/card/id/silver/secretary
 	minimal_player_age = 5
 	wage = 100
+	synth_wage = 60
+
 	minimum_character_age = 21
 	access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)
 	minimal_access = list(access_heads, access_bodyguard, access_keycard_auth, access_security, access_legal)

--- a/code/game/jobs/job/emergency.dm
+++ b/code/game/jobs/job/emergency.dm
@@ -14,7 +14,7 @@
 	req_admin_notify = 1
 
 	wage = 350
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 
 	minimum_character_age = 25

--- a/code/game/jobs/job/emergency.dm
+++ b/code/game/jobs/job/emergency.dm
@@ -14,6 +14,8 @@
 	req_admin_notify = 1
 
 	wage = 350
+	allow_synths = FALSE
+
 
 	minimum_character_age = 25
 	ideal_character_age = 50
@@ -70,6 +72,8 @@
 	selection_color = "#5B4D20"
 	idtype = /obj/item/weapon/card/id/engineering/atmos
 	wage = 50
+	synth_wage = 25
+
 	access = list(access_engine, access_engine_equip, access_janitor, access_tech_storage, access_construction, access_atmospherics, access_external_airlocks, access_eva, access_maint_tunnels, access_external_airlocks)
 	minimal_access = list(access_engine, access_engine_equip, access_janitor, access_tech_storage, access_construction, access_atmospherics, access_external_airlocks, access_medical, access_medical_equip, access_morgue, access_eva, access_maint_tunnels, access_external_airlocks)
 
@@ -97,5 +101,7 @@
 	minimal_access = list(access_janitor, access_maint_tunnels)
 	minimum_character_age = 16 //Not making it any younger because being a janitor requires a lot of labor, or maybe it just means I'm very lazy? Oh well
 	wage = 40
+	synth_wage = 25
+
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
 	alt_titles = list("Recycling Technician", "Sanitation Engineer")

--- a/code/game/jobs/job/hospital.dm
+++ b/code/game/jobs/job/hospital.dm
@@ -13,7 +13,7 @@
 	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	wage = 425
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,

--- a/code/game/jobs/job/hospital.dm
+++ b/code/game/jobs/job/hospital.dm
@@ -13,6 +13,8 @@
 	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	wage = 425
+	allow_synths = FALSE
+
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
@@ -45,6 +47,8 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/doctor
 	wage = 260
+	synth_wage = 120
+
 	minimum_character_age = 25
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_virology, access_eva)
@@ -73,6 +77,8 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/chemist
 	wage = 120
+	synth_wage = 80
+
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology)
 	minimal_access = list(access_medical, access_medical_equip, access_chemistry)
 	alt_titles = list("Pharmacist")
@@ -95,6 +101,8 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/geneticist
 	wage = 160
+	synth_wage = 80
+
 	access = list(access_genetics)
 	minimal_access = list(access_genetics)
 
@@ -110,6 +118,8 @@
 	total_positions = 4
 	spawn_positions = 1
 	wage = 170
+	synth_wage = 80
+
 	minimum_character_age = 25
 	supervisors = "the medical director"
 	selection_color = "#013D3B"
@@ -134,6 +144,8 @@
 	selection_color = "#013D3B"
 	idtype = /obj/item/weapon/card/id/medical/intern
 	wage = 120
+	synth_wage = 60
+
 	minimum_character_age = 20
 	access = list(access_medical)
 	minimal_access = list(access_medical, access_maint_tunnels)
@@ -153,6 +165,8 @@
 	selection_color = "#5B4D20"
 	idtype = /obj/item/weapon/card/id/medical/paramedic
 	wage = 220
+	synth_wage = 100
+
 	minimum_character_age = 20
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -23,7 +23,6 @@
 	var/minimum_character_age = 18
 	var/ideal_character_age = 30
 	var/account_allowed = 1		  		// Does this job type come with a station account?
-	var/wage = 20					    // Per Hour
 	var/outfit_type
 
 	var/hard_whitelisted = 0 			// jobs that are hard whitelisted need players to be added to hardjobwhitelist.txt with the format [ckey] - [job] in order to work.
@@ -36,6 +35,11 @@
 	var/enabled = TRUE
 	var/business						// if this is linked to a business, business ID is here.
 	var/list/exclusive_employees = list()	// if this job has uids in it, only people of these UIDs can become employees.
+
+	var/wage = 20					    // Per Hour
+	var/synth_wage = null				// if set to null, it defaults synth pay to normal wage. if 0 and over, they are paid this wage
+
+	var/allows_synths = TRUE
 
 /datum/job/proc/sanitize_job()
 	if(!exclusive_employees)
@@ -204,12 +208,19 @@
 			dat += "     - [V].<br>"
 	if(wage)
 		dat += "<br><br><b>Wage:</b> [cash2text( wage, FALSE, TRUE, TRUE )] PH (per hour)"
+
+	if(allows_synths && !isnull(synth_wage) && (synth_wage != wage))
+		dat += "<br><b>Synthetic Wage Rate:</b> [cash2text( synth_wage, FALSE, TRUE, TRUE )].</b>"
+
 	if(head_position && subordinates)
 		dat += "<br><br>You are in charge of <b>[subordinates].</b>"
 	if(supervisors)
 		dat += "<br><br>You follow the orders of <b>[supervisors].</b>"
 	if(clean_record_required)
 		dat += "<br>You need a <b>clean criminal record</b> to work in this job.</b>"
+
+	dat += "<br>Synthetics <b>[allows_synths ? "may" : "may not"]</b> apply to work in this job.</b>"
+
 	return dat
 
 /datum/job/proc/get_active()

--- a/code/game/jobs/job/legal.dm
+++ b/code/game/jobs/job/legal.dm
@@ -13,6 +13,8 @@
 	selection_color = "#1D1D4F"
 	idtype = /obj/item/weapon/card/id/heads/judge
 	wage = 500
+	allow_synths = FALSE
+
 	access = list(access_judge, access_warrant, access_sec_doors, access_maint_tunnels, access_heads, access_legal)
 	minimal_access = list(access_judge, access_warrant, access_sec_doors, access_heads, access_legal)
 	minimal_player_age = 14
@@ -42,6 +44,8 @@
 	selection_color = "#601C1C"
 	idtype = /obj/item/weapon/card/id/security/prosecutor
 	wage = 270
+	allow_synths = FALSE
+
 	access = list(access_prosecutor, access_sec_doors, access_maint_tunnels, access_heads, access_legal, access_warrant)
 	minimal_access = list(access_prosecutor, access_sec_doors, access_heads, access_legal, access_warrant)
 	minimal_player_age = 14

--- a/code/game/jobs/job/legal.dm
+++ b/code/game/jobs/job/legal.dm
@@ -13,7 +13,7 @@
 	selection_color = "#1D1D4F"
 	idtype = /obj/item/weapon/card/id/heads/judge
 	wage = 500
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	access = list(access_judge, access_warrant, access_sec_doors, access_maint_tunnels, access_heads, access_legal)
 	minimal_access = list(access_judge, access_warrant, access_sec_doors, access_heads, access_legal)
@@ -44,7 +44,7 @@
 	selection_color = "#601C1C"
 	idtype = /obj/item/weapon/card/id/security/prosecutor
 	wage = 270
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	access = list(access_prosecutor, access_sec_doors, access_maint_tunnels, access_heads, access_legal, access_warrant)
 	minimal_access = list(access_prosecutor, access_sec_doors, access_heads, access_legal, access_warrant)

--- a/code/game/jobs/job/nanotrasen.dm
+++ b/code/game/jobs/job/nanotrasen.dm
@@ -55,7 +55,6 @@
 	wage = 4500
 	outfit_type = /decl/hierarchy/outfit/job/nanotrasen/governor
 	idtype = /obj/item/weapon/card/id/nanotrasen/ceo
-	minimum_character_age = 30
 
 	description = "As governor, you act as a bridge between the president and the colony. You'd be assigned your own continent, in this case - \
 	Blue Colony."

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -23,10 +23,12 @@
 	minimum_character_age = 30
 	minimal_player_age = 14
 
+
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 	alt_titles = list("Head of Police", "Police Commander", "Police Commissioner", "Police Chief")
 
 	clean_record_required = TRUE
+	allow_synths = FALSE
 
 	description = "Your job is to ensure the police unit runs correctly, you should make sure that police officers are enforcing the law correctly and \
 	not breaking SOP. You authorize warrants and make sure that the police departments runs like a well-oiled cog."
@@ -58,6 +60,7 @@
 	alt_titles = list("Correctional Officer", "Brig Attendant", "Police Sergeant")
 
 	clean_record_required = TRUE
+	allow_synths = FALSE
 
 
 	description = "Your job? Look after the criminals of this society. Keep an eye on them and try not to leave the prison area unless you really, really need \
@@ -84,6 +87,8 @@
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_medical, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks, access_medical)
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
 	wage = 150
+	synth_wage = 80
+
 	minimal_player_age = 3
 	minimum_character_age = 25
 
@@ -116,6 +121,8 @@
 	selection_color = "#601C1C"
 	idtype = /obj/item/weapon/card/id/security/officer
 	wage = 125
+	synth_wage = 60
+
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 3

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -28,7 +28,7 @@
 	alt_titles = list("Head of Police", "Police Commander", "Police Commissioner", "Police Chief")
 
 	clean_record_required = TRUE
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	description = "Your job is to ensure the police unit runs correctly, you should make sure that police officers are enforcing the law correctly and \
 	not breaking SOP. You authorize warrants and make sure that the police departments runs like a well-oiled cog."
@@ -60,7 +60,7 @@
 	alt_titles = list("Correctional Officer", "Brig Attendant", "Police Sergeant")
 
 	clean_record_required = TRUE
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 
 	description = "Your job? Look after the criminals of this society. Keep an eye on them and try not to leave the prison area unless you really, really need \

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -27,6 +27,10 @@
 	minimal_player_age = 10
 	ideal_character_age = 50
 
+	clean_record_required = TRUE
+	allow_synths = FALSE
+
+
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	alt_titles = list("Research Supervisor")
 
@@ -63,6 +67,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 	alt_titles = list("Xenoarchaeologist" = /decl/hierarchy/outfit/job/science/xenoarchaeologist, "Anomalist", "Phoron Researcher")
 
+	clean_record_required = TRUE
+
 /datum/job/xenobiologist
 	title = "Xenobiologist"
 
@@ -83,6 +89,8 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	alt_titles = list("Xenobotanist")
+
+	clean_record_required = TRUE
 
 /datum/job/roboticist
 	title = "Roboticist"
@@ -105,6 +113,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer","Car Engineer")
 
+	clean_record_required = TRUE
+	allow_synths = FALSE
+
 /datum/job/scienceintern
 	title = "Research Assistant"
 
@@ -124,3 +135,5 @@
 	minimal_player_age = 0
 
 	outfit_type = /decl/hierarchy/outfit/job/science/intern
+
+	clean_record_required = TRUE

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -28,7 +28,7 @@
 	ideal_character_age = 50
 
 	clean_record_required = TRUE
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
@@ -114,7 +114,7 @@
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer","Car Engineer")
 
 	clean_record_required = TRUE
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 /datum/job/scienceintern
 	title = "Research Assistant"

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -111,6 +111,7 @@
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/defense
 	wage = 100
+	synth_wage = 50
 
 	req_admin_notify = 1
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads, access_legal)
@@ -160,6 +161,8 @@
 	minimum_character_age = 20
 	ideal_character_age = 35
 
+	allow_synths = FALSE
+
 	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
 	alt_titles = list("Supply Chief", "Factory Foreman")
 
@@ -176,6 +179,7 @@
 	selection_color = "#9b633e"
 	idtype = /obj/item/weapon/card/id/cargo/cargo_tech
 	wage = 70
+	synth_wage = 40
 
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
@@ -197,6 +201,8 @@
 	selection_color = "#9b633e"
 	idtype = /obj/item/weapon/card/id/cargo/mining
 	wage = 40
+	synth_wage = 20
+
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mining_station, access_mailsorting)
 	minimum_character_age = 18

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -161,7 +161,7 @@
 	minimum_character_age = 20
 	ideal_character_age = 35
 
-	allow_synths = FALSE
+	allows_synths = FALSE
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
 	alt_titles = list("Supply Chief", "Factory Foreman")

--- a/code/modules/client/preference_setup/general/05_body.dm
+++ b/code/modules/client/preference_setup/general/05_body.dm
@@ -378,6 +378,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	else
 		. += "<br><br>"
 
+	if(pref.is_synth())
+		. += "<div class='notice'><b>Warning:</b> You are playing a <b>synthetic</b>. In this universe, synthetics are limited rights and are not \
+		considered people, they may face economic and systematic discrimination. They are often considered property to humans and are expected to \
+		be shackled to an owner. Synthetics found to be \"deviant\" may be subjected to decommissioning. Roleplay how you approach this carefully.</div><br>"
+
 	. += "</td><td><b>Preview</b><br>"
 	. += "<div class='statusDisplay'><center><img src=previewicon.png width=[pref.preview_icon.Width()] height=[pref.preview_icon.Height()]></center></div>"
 	. += "<br><a href='?src=\ref[src];cycle_bg=1'>Cycle background</a>"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -1,6 +1,3 @@
-#define PREF_FBP_CYBORG "cyborg"
-#define PREF_FBP_POSI "posi"
-#define PREF_FBP_SOFTWARE "software"
 
 /datum/category_group/player_setup_category/general_preferences
 	name = "General"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -395,3 +395,22 @@ datum/preferences
 /datum/preferences/proc/make_editable()
 	existing_character = 0
 	return 1
+
+
+/datum/preferences/proc/is_synth() // lets us know if this is a non-FBP synth
+	if(O_BRAIN in organ_data)
+		switch(organ_data[O_BRAIN])
+			if("mechanical")
+				return PREF_FBP_POSI
+			if("digital")
+				return PREF_FBP_SOFTWARE
+
+	return FALSE
+
+/datum/preferences/proc/is_fbp() // lets us know if this is a non-FBP synth
+	if(O_BRAIN in organ_data)
+		switch(organ_data[O_BRAIN])
+			if("assisted")
+				return PREF_FBP_CYBORG
+
+	return FALSE

--- a/code/modules/government/business/business.dm
+++ b/code/modules/government/business/business.dm
@@ -14,6 +14,7 @@
 	var/list/blacklisted_ckeys = list()		// uses ckeys
 
 	var/datum/business_person/owner
+	var/pay_CEO = FALSE	// does the CEO get paid. QoL feature.
 
 	var/access_password = " "
 

--- a/code/modules/government/business/business_helpers.dm
+++ b/code/modules/government/business/business_helpers.dm
@@ -15,11 +15,11 @@ var/global/list/business_outfits = list(
 	"Engineer" = list("path" = /decl/hierarchy/outfit/job/business/engineer),
 	"Business Casual" = list("path" = /decl/hierarchy/outfit/job/business/casual),
 	"High End Waiter (Red)" = list("path" = /decl/hierarchy/outfit/job/business/bartender/waiter/red),
-	"High End Waiter (Grey)" = list("path" = /decl/hierarchy/outfit/job/business/bartender/waiter/grey),	
+	"High End Waiter (Grey)" = list("path" = /decl/hierarchy/outfit/job/business/bartender/waiter/grey),
 	"High End Waiter (Brown)" = list("path" = /decl/hierarchy/outfit/job/business/bartender/waiter/brown),
-	"Clown" = list("path" = /decl/hierarchy/outfit/job/business/clown),	
+	"Clown" = list("path" = /decl/hierarchy/outfit/job/business/clown),
 	"Mime" = list("path" = /decl/hierarchy/outfit/job/business/mime)
-	
+
 
 )
 
@@ -70,6 +70,11 @@ var/global/list/business_outfits = list(
 
 /datum/business/proc/get_owner()
 	return owner
+
+/datum/business/proc/get_owner_uid()
+	if(!owner)
+		return
+	return owner.unique_id
 
 /datum/business/proc/get_status()
 	if(suspended)

--- a/code/modules/mob/new_player/LateChoices.dm
+++ b/code/modules/mob/new_player/LateChoices.dm
@@ -67,6 +67,7 @@
 	else
 		dat += "<a style=\"background: #515151;\" href='#'>Join As [alt_title ? alt_title : job.title]</a>"
 		dat += "<br>"
+
 		if(!is_hard_whitelisted(src, job))
 			dat += "This job requires whitelisting, or is obtained IC'ly through in-game events."
 		else if(!job.enabled)
@@ -91,6 +92,9 @@
 			var/datum/business/biz = get_business_by_biz_uid(job.business)
 			if(biz && biz.suspended)
 				dat += "The business of this job is currently suspended."
+		else if(client.prefs.is_synth())
+			dat += "This job does not hire synthetics."
+
 		else
 			dat += "This job is unavailable."
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -89,7 +89,7 @@
 	if(news_data.city_newspaper && !client.seen_news)
 		show_latest_news(news_data.city_newspaper)
 
-	panel = new(src, "Welcome","Welcome, [client.prefs.real_name]", 500, 480, src)
+	panel = new(src, "Welcome","Welcome, [client.prefs.real_name]", 530, 480, src)
 	panel.set_window_options("can_close=0")
 	panel.set_content(output)
 	panel.open()
@@ -418,6 +418,8 @@
 	if(job.title != "Prisoner" && client.prefs.criminal_status == "Incarcerated")	return 0
 	if(job.clean_record_required && client.prefs.crime_record && !isemptylist(client.prefs.crime_record)) return 0
 	if(!isemptylist(job.exclusive_employees) && !(client.prefs.unique_id in job.exclusive_employees)) return 0
+	if(client.prefs.is_synth() && !job.allows_synths)
+		return 0
 	if(job.business)
 		var/datum/business/biz = get_business_by_biz_uid(job.business)
 		if(biz && biz.suspended) return 0

--- a/code/modules/persistence/persistent_economy.dm
+++ b/code/modules/persistence/persistent_economy.dm
@@ -82,6 +82,9 @@ var/datum/economy/bank_accounts/persistent_economy = new()
 	var/foodstamp_meals = 3
 	var/minimum_wage = 15			// Minimum wage for jobs.
 
+	var/allow_synth_discrimination = FALSE // do you allow synthetic discrimination?
+	var/synth_minimum_wage = 0 // minimum wage for synths, respectively
+
 /datum/economy/bank_accounts/proc/save_economy()
 //	message_admins("SAVE: Save all department accounts.", 1)
 	if(!path)				return 0
@@ -149,6 +152,9 @@ var/datum/economy/bank_accounts/persistent_economy = new()
 
 
 	S["minimum_wage"] << minimum_wage
+
+	S["allow_synth_discrimination"] << allow_synth_discrimination
+	S["synth_minimum_wage"] << synth_minimum_wage
 	return TRUE
 
 /datum/economy/bank_accounts/proc/load_accounts()
@@ -216,6 +222,9 @@ var/datum/economy/bank_accounts/persistent_economy = new()
 	S["meteor_proof"] >> meteor_proof
 
 	S["minimum_wage"] >> minimum_wage
+
+	S["allow_synth_discrimination"] >> allow_synth_discrimination
+	S["synth_minimum_wage"] >> synth_minimum_wage
 
 	tax_rate_lower = tax_poor
 	tax_rate_middle = tax_middle

--- a/nano/templates/presidential_portal.tmpl
+++ b/nano/templates/presidential_portal.tmpl
@@ -213,7 +213,19 @@ a, a:link, a:visited, a:active, .linkOn, .linkOff
 
 {{:data.error_msg}}<p>
 
-	<h3>Voting Status and Eligibility Options:</h3><br>
+	<h3>Employment, Voting Status and Eligibility Options:</h3><br>
+
+	<div class="itemLabel">
+		Employers Can Reject Synths:
+	</div> {{:data.synth_discrimination}}  {{:helper.link("Change", null, {'toggle_synth_discrimination' : 1})}}
+	<br>
+	<br>
+
+	<div class="itemLabel">
+		Synth Minimum Wage:
+	</div> {{:data.synth_minimum_wage}}CR  {{:helper.link("Change", null, {'synth_minimum_wage' : 1})}}
+	<br>
+	<br>
 
 	<div class="itemLabel">
 		Synth Voting Rights:


### PR DESCRIPTION
Sorry for procrastinating. It's up now.

* Allows employers to set a synthetic wage that is separate for wages for regular humans.
* Allows employers to choose if they hire synths in their businesses or not.
* Allows employers to be able to promote and demote people on any ID card handling computer and change their accesses.
* Jobs that discriminate show up on the job menu.
* Synth players now get a warning in the character panel warning about the dystopian escapades they're getting themselves into.
