### PR TITLE
Governor/VP Job Spawn Changes

### DIFF
--- a/code/game/jobs/job/nanotrasen.dm
+++ b/code/game/jobs/job/nanotrasen.dm
@@ -46,8 +46,8 @@
 
 /datum/job/nanotrasen/ceo
 	title = "Governor"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2 // This allows VP and Governor to be on at the same time without staff intervention.
 	flag = CEO
 	alt_titles = list("Advisor" = /decl/hierarchy/outfit/job/nanotrasen/minister,
 	 "Vice President" = /decl/hierarchy/outfit/job/heads/vpresident,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change affects solely the Governor position. The VP role is tied directly to the Governor's job slot so instead of making VP it's own role, I've established two slots instead of one.

## Why It's Good For The Game

<!--  -->
This'll allow the VP and Governor to be on without staff having to make changes to the job mid-round.

## Changelog
:cl:
tweak: tweaked a few things
code: changed some code
/:cl: