### PR TITLE
Fixes Permit purchases on vendors

### DIFF
--- a/code/modules/clothing/under/accessories/permits.dm
+++ b/code/modules/clothing/under/accessories/permits.dm
@@ -104,6 +104,12 @@ GLOBAL_LIST_INIT(permit_types, list(
 	desc = "A card indicating that the owner is allowed to carry a firearm while on the surface."
 	tiered = FALSE
 
+/obj/item/clothing/accessory/permit/gun/proc/get_tier()
+	if(!tier)
+		return 0
+	else
+		return tier
+
 /obj/item/clothing/accessory/permit/drone
 	name = "drone identification card"
 	desc = "A card issued by the government, indicating that the owner is a Drone Intelligence. Drones are mandated to carry this card on PolGov colonies, by law."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Refactors vendor code so it doesn't require an exact permit /obj/ match. Only the requested tier is needed to purchase. Also fixes the issue of not being able to purchase a low-tier item with a higher tier permit. (i.e. Tier 2 weapon in vendor can now be purchased with Tier 2, 3, 4, and 5 permits.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fixes always good.

## Changelog
:cl:
refactor: electronic_display permit code
fix: can now buy low tier items with higher tier permits
remove: nuclear warhead permit removed from city clerk's locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->