### PR TITLE
Adds city bounced radios to the GCPD vendors

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1222,7 +1222,8 @@
 	/obj/item/device/hailer = 6,
 	/obj/item/device/holowarrant = 8,
 	/obj/item/device/breathalyzer = 8,
-	/obj/item/device/retail_scanner/police = 8
+	/obj/item/device/retail_scanner/police = 8,
+	/obj/item/device/radio = 6
 	)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 6 city bounced radios to the GCPD vendors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It allows police members to communicate when the main comms are down. City bounced radios were present in the old map, why not add them back? Also EMTs have city bounced radios.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new things
add: Added more things
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->