### PR TITLE
Ports image persistence from Ingame Case DB project.

### DIFF
--- a/code/__defines/persistence_defines.dm
+++ b/code/__defines/persistence_defines.dm
@@ -1,0 +1,2 @@
+// Note: These MUST end with a trailing slash `/`.
+#define PERSISTENT_PHOTO_DIRECTORY "data/persistent/images/photos/"

--- a/code/controllers/subsystems/initialization/persistence.dm
+++ b/code/controllers/subsystems/initialization/persistence.dm
@@ -53,3 +53,40 @@ SUBSYSTEM_DEF(persistence)
 	var/datum/browser/popup = new(user, "admin_persistence", "Persistence Data")
 	popup.set_content(jointext(dat, null))
 	popup.open()
+
+
+// Persistent images.
+// Used for things like photos, and the Case DB. All files are `.png`.
+
+// Make sure `image_id` is unique or else images will be overwritten.
+
+// Saves an image file to disk outside of the cache, so it gets perserved.
+/datum/controller/subsystem/persistence/proc/save_image(image, image_id, image_directory)
+	var/full_path = "[image_directory][image_id].png"
+	var/icon/image_to_save = icon(image, dir = SOUTH, frame = 1)
+	fcopy(image_to_save, full_path)
+
+// Loads an image from disk to an icon object.
+// Avoid repeatively calling this if possible.
+/datum/controller/subsystem/persistence/proc/load_image(image_id, image_directory)
+	var/full_path = "[image_directory][image_id].png"
+	if(!fexists(full_path))
+		CRASH("Asked to load a nonexistent image file '[full_path]'.")
+	var/icon/loaded_image = icon(file(full_path))
+	return loaded_image
+
+
+
+// Deletes an image from disk.
+/datum/controller/subsystem/persistence/proc/delete_image(image_id, image_directory)
+	var/full_path = "[image_directory][image_id].png"
+	if(fexists(full_path))
+		fdel(full_path)
+		return TRUE
+	CRASH("Asked to delete a nonexistent image file '[full_path]'.") 
+
+// Checks if the full path actually exists.
+// Use if you're not sure if `load_image` or `delete_image` will succeed for whatever reason.
+/datum/controller/subsystem/persistence/proc/image_exists(image_id, image_directory)
+	var/full_path = "[image_directory][image_id].png"
+	return fexists(full_path)

--- a/polaris.dme
+++ b/polaris.dme
@@ -56,6 +56,7 @@
 #include "code\__defines\MC.dm"
 #include "code\__defines\misc.dm"
 #include "code\__defines\mobs.dm"
+#include "code\__defines\persistence_defines.dm"
 #include "code\__defines\planets.dm"
 #include "code\__defines\process_scheduler.dm"
 #include "code\__defines\qdel.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cassie asked if she could have the system that makes photos persistent early, for a project she has planned.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes photos properly persistent ingame, and also adds a basic system of saving, loading, and deleting images from disk.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Photos are now persistent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->