### PR TITLE
Alien Enhancement Vest Rebalance

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -213,15 +213,16 @@
 /obj/item/clothing/suit/armor/alien
 	name = "alien enhancement vest"
 	desc = "It's a strange piece of what appears to be armor. It looks very light and agile. Strangely enough it seems to have been designed for a humanoid shape."
-	description_info = "It has a 20% chance to completely nullify an incoming attack, and the wearer moves slightly faster."
+	description_info = "It has a 10% chance to absorb the kinetic energy of an attack. When the kinetic weave is overloaded, it will release a shockwave that knocks back everything within 2 meters."
 	icon_state = "alien_speed"
 	blood_overlay_type = "armor"
 	item_state_slots = list(slot_r_hand_str = "armor", slot_l_hand_str = "armor")
-	slowdown = -1
+	slowdown = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 0, rad = 40)
 	siemens_coefficient = 0.4
-	var/block_chance = 20
+	var/block_chance = 10
+	var/kinetic_charge = 0
 
 /obj/item/clothing/suit/armor/alien/tank
 	name = "alien protection suit"
@@ -235,9 +236,24 @@
 
 /obj/item/clothing/suit/armor/alien/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(prob(block_chance))
-		user.visible_message("<span class='danger'>\The [src] completely absorbs [attack_text]!</span>")
-		return TRUE
+		if(kinetic_charge >= 100)
+			var/turf/T = get_turf(user)
+			user.visible_message("<span class='danger'>\The [src] releases a kinetic charge!</span>")
+			shockwave(T, kinetic_charge)
+			return TRUE
+		else
+			user.visible_message("<span class='danger'>\The [src] completely absorbs [attack_text]!</span>")
+			kinetic_charge += damage/10
+			return TRUE
 	return FALSE
+
+/obj/item/clothing/suit/armor/alien/proc/shockwave(turf/T, kinetic_charge)
+	for(var/atom/movable/X in view(2))
+		if(istype(X, /obj/effect))
+			continue
+		if(X && !X.anchored)
+			X.throw_at(get_edge_target_turf(T, get_dir(T, X)), round(kinetic_charge/10), 1 + round(kinetic_charge/10))
+	return TRUE
 
 //Non-hardsuit ERT armor.
 /obj/item/clothing/suit/armor/vest/ert


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

AEV no longer speeds up the user when worn.
Block Chance reduced to 10% from 20%.
AEV now has a shockwave ability. When it successfully absorbs an attack, the damage done will be added to the AEV's kinetic charge. When the suit is overloaded, it will release the built up kinetic energy and knockback everything within 2 tiles of the user. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more sanic go fast meth/AEV combos.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Alien enhancement vest no longer speeds up users
add: Alien enhancement vest will release a shockwave after it absorbs enough damage
balance: Alien enhancement vest block chance reduced to every 1 in 10 hits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->