### PR TITLE
Self-Surgery

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1217,12 +1217,19 @@ proc/is_hot(obj/item/W as obj)
 
 // check if mob is lying down on something we can operate him on.
 // The RNG with table/rollerbeds comes into play in do_surgery() so that fail_step() can be used instead.
-/proc/can_operate(mob/living/carbon/M)
-	return M.lying
+/proc/can_operate(mob/living/carbon/M, mob/living/user)
+	. = M.lying
+
+	if(user && M == user && user.allow_self_surgery && user.a_intent == I_HELP)	// You can, technically, always operate on yourself after standing still. Inadvised, but you can.
+
+		if(!M.isSynthetic())
+			. = TRUE
+
+	return .
 
 // Returns an instance of a valid surgery surface.
-/mob/living/proc/get_surgery_surface()
-	if(!lying)
+/mob/living/proc/get_surgery_surface(mob/living/user)
+	if(!lying && user != src)
 		return null // Not lying down means no surface.
 	var/obj/surface = null
 	for(var/obj/O in loc) // Looks for the best surface.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -45,7 +45,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(!ismob(user))
 		return 0
 
-	if(can_operate(src) && I.do_surgery(src,user))
+	if(can_operate(src, user) && I.do_surgery(src,user))
 		if(I.can_do_surgery(src,user))
 			return 1
 		else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -55,6 +55,8 @@
 		dna.real_name = real_name
 		sync_organ_dna()
 
+	verbs |= /mob/living/proc/toggle_selfsurgery
+
 /mob/living/carbon/human/Destroy()
 	human_mob_list -= src
 	for(var/organ in organs)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -60,3 +60,5 @@
 	var/list/hud_list		//Holder for health hud, status hud, wanted hud, etc (not like inventory slots)
 	var/has_huds = FALSE	//Whether or not we should bother initializing the above list
 	var/looking_elsewhere = FALSE //If the mob's view has been relocated to somewhere else, like via a camera or with binocs
+
+	var/allow_self_surgery = FALSE	// Used to determine if the mob can perform surgery on itself.

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -15,3 +15,13 @@
 		layer = HIDING_LAYER //Just above cables with their 2.44
 		plane = OBJ_PLANE
 		to_chat(src,"<span class='notice'>You are now hiding.</span>")
+
+/mob/living/proc/toggle_selfsurgery()
+	set name = "Allow Self Surgery"
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
+	set category = "Object"
+
+	allow_self_surgery = !allow_self_surgery
+
+	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
+	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -766,7 +766,7 @@
 
 /* Antidepressants */
 
-#define ANTIDEPRESSANT_MESSAGE_DELAY 50*600*100
+#define ANTIDEPRESSANT_MESSAGE_DELAY 50*60*100
 
 /datum/reagent/methylphenidate
 	name = "Methylphenidate"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -766,7 +766,7 @@
 
 /* Antidepressants */
 
-#define ANTIDEPRESSANT_MESSAGE_DELAY 5*60*10
+#define ANTIDEPRESSANT_MESSAGE_DELAY 50*600*100
 
 /datum/reagent/methylphenidate
 	name = "Methylphenidate"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -109,6 +109,7 @@
 		//check if tool is right or close enough and if this step is possible
 		if(S.tool_quality(src))
 			var/step_is_valid = S.can_use(user, M, zone, src)
+			if(step_is_valid && S.is_valid_target(M))
 
 				if(M == user)	// Once we determine if we can actually do a step at all, give a slight delay to self-surgery to confirm attempts.
 					to_chat(user, "<span class='critical'>You focus on attempting to perform surgery upon yourself.</span>")
@@ -116,7 +117,6 @@
 					if(!do_after(user, 3 SECONDS, M))
 						return 0
 
-			if(step_is_valid && S.is_valid_target(M))
 				if(step_is_valid == SURGERY_FAILURE) // This is a failure that already has a message for failing.
 					return 1
 				M.op_stage.in_progress += zone

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -84,8 +84,8 @@
 
 
 /obj/item/proc/can_do_surgery(mob/living/carbon/M, mob/living/user)
-	if(M == user)
-		return 0
+//	if(M == user)
+//		return 0
 	if(!ishuman(M))
 		return 1
 	var/mob/living/carbon/human/H = M
@@ -109,6 +109,13 @@
 		//check if tool is right or close enough and if this step is possible
 		if(S.tool_quality(src))
 			var/step_is_valid = S.can_use(user, M, zone, src)
+
+				if(M == user)	// Once we determine if we can actually do a step at all, give a slight delay to self-surgery to confirm attempts.
+					to_chat(user, "<span class='critical'>You focus on attempting to perform surgery upon yourself.</span>")
+
+					if(!do_after(user, 3 SECONDS, M))
+						return 0
+
 			if(step_is_valid && S.is_valid_target(M))
 				if(step_is_valid == SURGERY_FAILURE) // This is a failure that already has a message for failing.
 					return 1
@@ -121,7 +128,7 @@
 					success = FALSE
 
 				// Bad or no surface may mean failure as well.
-				var/obj/surface = M.get_surgery_surface()
+				var/obj/surface = M.get_surgery_surface(user)
 				if(!surface || !prob(surface.surgery_odds))
 					success = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports Mechoid's Self-Surgery PR from PolarisSS13

> Allows organics to self-surgery after toggling the surgical safety in the object tab. It follows the same rules as normal surgery.
> FBPs cannot repair their own internal damage, but a Human with a prosthetic limb can repair its internal damage.

Also increases the anti-depressant message delay so it no longer spams a player when taken.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Live your cyberpunk future by repairing your battered cyberarm in the sewers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Players can now perform surgery on themselves with all the consequences that entails.
fix: Antidepressant spam fixed.
remove: Bluespace Combi-Surgical Tool removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->