### PR TITLE
Popcorn Vendor Fix

### DIFF
--- a/code/game/machinery/arcade.dm
+++ b/code/game/machinery/arcade.dm
@@ -125,6 +125,9 @@
 /obj/machinery/food_machine/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	var/obj/item/weapon/card/id/I = W.GetID()
 
+	if(!istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown) || !istype(W,/obj/item/weapon/card/id) || !istype(W,/obj/item/weapon/spacecash/ewallet || !istype(W,/obj/item/weapon/spacecash)) //i hate looking at this line
+		return
+
 	if(!owner_uid && I)
 		if(!I.unique_ID || !I.registered_name || !I.associated_account_number || !check_account_exists(I.associated_account_number))
 			visible_message("<span class='notice'>There is an issue with setting your ownership on this message, it could be due to a lack of details on the card like \

--- a/code/game/machinery/arcade.dm
+++ b/code/game/machinery/arcade.dm
@@ -125,7 +125,7 @@
 /obj/machinery/food_machine/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	var/obj/item/weapon/card/id/I = W.GetID()
 
-	if(!istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown) || !istype(W,/obj/item/weapon/card/id) || !istype(W,/obj/item/weapon/spacecash/ewallet || !istype(W,/obj/item/weapon/spacecash)) //i hate looking at this line
+	if(!istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown) || !istype(W,/obj/item/weapon/card/id) || !istype(W,/obj/item/weapon/spacecash/ewallet) || !istype(W,/obj/item/weapon/spacecash)) //i hate looking at this line
 		return
 
 	if(!owner_uid && I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Popcorn vendors will no longer dispense free popcorn if attacked with an object that is not an ID or cash.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Free stuff bad. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: popcorn vendors no longer dispense free popcorn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->