### PR TITLE
Self-Surgery rebalance

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -112,6 +112,10 @@
 			if(step_is_valid && S.is_valid_target(M))
 
 				if(M == user)	// Once we determine if we can actually do a step at all, give a slight delay to self-surgery to confirm attempts.
+					if(zone == O_EYES || zone == O_MOUTH || zone == BP_HEAD || zone == BP_TORSO || zone == BP_GROIN)
+						to_chat(user, span("critical", "You cannot perform self-surgery on that area!"))
+						return 0
+
 					to_chat(user, "<span class='critical'>You focus on attempting to perform surgery upon yourself.</span>")
 
 					if(!do_after(user, 3 SECONDS, M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Players can no longer perform self surgery on the Head, Eyes, Mouth, Torso, or Groin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Balancing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Self-Surgery can only be performed on the legs, feet, arms, and hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->