### PR TITLE
Adds NT IRC to default communicator programs

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_comm_internal.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_comm_internal.dm
@@ -21,6 +21,7 @@
 	..()
 	hard_drive.store_file(new/datum/computer_file/program/nttransfer())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
+	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/nt_explorer())
 	hard_drive.store_file(new/datum/computer_file/program/landlord_management())
 	hard_drive.store_file(new/datum/computer_file/program/business_manager())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the NT IRC program to the default installed programs on the communicator.

## Why It's Good For The Game

Although the NT IRC program already existed, many people didn't know it did as a result of you having to download it every round, this made it very inconvenant for people to use / know about, it's a good way for groups of any kind to communicate together through IC means easily, public or privately.

## Changelog
:cl:
add: NT IRC program to default communicator apps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->