### PR TITLE
More Factory Exploit Fixes

### DIFF
--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -156,7 +156,7 @@
  			/obj/item/target/alien = 2,
  			/obj/item/target/syndicate = 2
  			)
- 	cost = 2500
+ 	cost = 7000
  	containertype = /obj/structure/closet/crate/secure/weapon
  	containername = "Ballistic weapons crate"
  	access = access_security

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -16,7 +16,7 @@
 	var/initialize_loc = BP_TORSO
 	show_messages = 1
 
-	price_tag = 1000
+	price_tag = 10
 
 /obj/item/weapon/implant/proc/trigger(emote, source as mob)
 	return

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -10,7 +10,7 @@
 	throw_range = 5
 	w_class = ITEMSIZE_TINY
 	var/obj/item/weapon/implant/imp = null
-	price_tag = 1000
+	price_tag = 10
 
 /obj/item/weapon/implantcase/proc/update()
 	if (src.imp)


### PR DESCRIPTION

## About The Pull Request

Changes a crate of competitive shooting guns cost to 7000 to fit with the base price so it cant be exported for insane profit, and sets death alarms to export for 10 so RnD cant export a crapload of chem implants to break the economy , and people cant abuse death alarms at the factory for the same purpose.

## Why It's Good For The Game

Fixes exploits that break the economy

## Changelog
:cl:

tweak: 
~Changes Competitive shooting rifles crate at the factory from 2500 to 7000
~Changes implant and implant case price_tag from 1000 to 10

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->