### PR TITLE
FBP saving hotfix

### DIFF
--- a/code/modules/persistence/persistent_characters.dm
+++ b/code/modules/persistence/persistent_characters.dm
@@ -75,6 +75,9 @@
 
 		else
 			if(current_limb.robotic)
+				if(istype(current_limb, /obj/item/organ/external/head))
+					if(!isSynthetic())
+						mind.prefs.organ_data[O_BRAIN] = "assisted"
 				mind.prefs.rlimb_data[current_limb.icon_name] = current_limb.model
 				mind.prefs.organ_data[current_limb.icon_name] = "cyborg"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Those who convert to FBPs mid-round will have their brains converted to MMIs when saving.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No soft brains in mechanical heads.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: FBP brain saving fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->