### PR TITLE
Disposable Teleporter Nerf + ZEUS buff

### DIFF
--- a/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
+++ b/code/game/gamemodes/technomancer/devices/disposable_teleporter.dm
@@ -47,6 +47,10 @@
 		sparks.attach(user)
 		sparks.start()
 
+		if(A.security_system)
+			to_chat(user, "\The [src] was unable to teleport you to that area - it appears a security system is blocking you.")
+			return
+
 		if(user && user.buckled)
 			user.buckled.unbuckle_mob()
 
@@ -63,8 +67,8 @@
 				targets.Add(T)
 
 		if(!targets.len)
-			user << "\The [src] was unable to locate a suitable teleport destination, as all the possibilities \
-			were nonexistant or hazardous. Try a different area."
+			to_chat(user, "\The [src] was unable to locate a suitable teleport destination, as all the possibilities \
+			were nonexistant or hazardous. Try a different area.")
 			return
 		var/turf/simulated/destination = null
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -367,7 +367,10 @@
 		do_animate("deny")
 	return
 
-/obj/machinery/door/emag_act(var/remaining_charges)
+/obj/machinery/door/emag_act(var/remaining_charges, var/mob/user)
+	if(trigger_lot_security_system(user, /datum/lot_security_option/intrusion, "Attempted to emag \the [src]."))
+		return
+
 	if(density && operable())
 		do_animate("emag")
 		sleep(6)

--- a/code/game/machinery/lot_security_system.dm
+++ b/code/game/machinery/lot_security_system.dm
@@ -45,10 +45,17 @@
 	zap_power = INFINITY
 	hardened = TRUE
 	desired_area_type = /area
+	owner_uid = "Nanotrasen"
 
 /obj/machinery/lot_security_system/centcom/president	// for the commander in chief
 	name = "Presidential Z.E.U.S. System Deluxe"
 	innate_access_exemptions = list(access_president)
+
+/obj/machinery/lot_security_system/centcom/police
+	name = "Police Z.E.U.S. System Deluxe"
+	innate_access_exemptions = list(access_security)
+	damage_to_criminals = 0 // avoid police lawsuits lol
+	hardened = FALSE // should be empable
 
 // The kind you get straight from the factory, only difference is that it doesn't start anchored.
 /obj/machinery/lot_security_system/factory_ordered

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -16,6 +16,9 @@
 		if(!action_checks(target)) return
 		if(!cargo_holder) return
 
+		if(chassis.occupant && trigger_lot_security_system(chassis.occupant, /datum/lot_security_option/theft, "Attempted to load \the [target] onto \the [chassis]."))
+			return
+
 		//loading
 		if(istype(target,/obj))
 			var/obj/O = target
@@ -82,6 +85,10 @@
 		if(isobj(target))
 			var/obj/target_obj = target
 			if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
+
+		if(chassis.occupant && trigger_lot_security_system(chassis.occupant, /datum/lot_security_option/intrusion, "Attempted to drill \the [target] with \the [chassis]."))
+			return
+
 		set_ready_state(0)
 		chassis.use_power(energy_drain)
 		chassis.visible_message("<span class='danger'>[chassis] starts to drill [target]</span>", "<span class='warning'>You hear the drill.</span>")
@@ -133,6 +140,10 @@
 		if(isobj(target))
 			var/obj/target_obj = target
 			if(target_obj.unacidable)	return
+
+		if(chassis.occupant && trigger_lot_security_system(chassis.occupant, /datum/lot_security_option/intrusion, "Attempted to drill \the [target] with \the [chassis]."))
+			return
+
 		set_ready_state(0)
 		chassis.use_power(energy_drain)
 		chassis.visible_message("<span class='danger'>[chassis] starts to drill [target]</span>", "<span class='warning'>You hear the drill.</span>")
@@ -252,6 +263,10 @@
 			disabled = 0
 		if(!istype(target, /turf) && !istype(target, /obj/machinery/door/airlock))
 			target = get_turf(target)
+
+		if(chassis.occupant && trigger_lot_security_system(chassis.occupant, /datum/lot_security_option/intrusion, "Attempted to drill \the [target] with \the [chassis]."))
+			return
+
 		if(!action_checks(target) || disabled || get_dist(chassis, target)>3) return
 		playsound(chassis, 'sound/machines/click.ogg', 50, 1)
 		//meh
@@ -997,6 +1012,10 @@
 	action(atom/target)
 		if(!action_checks(target)) return
 		if(!cargo_holder) return
+
+		if(chassis.occupant && trigger_lot_security_system(chassis.occupant, /datum/lot_security_option/theft, "Attempted to load \the [target] onto \the [chassis]."))
+			return
+
 		if(istype(target,/obj))
 			var/obj/O = target
 			if(!O.anchored)


### PR DESCRIPTION
All activated ZEUS systems, regardless of charge status now passively block teleportations into lots. This update also buffs ZEUS units to detect emags and mechas, this will be useful later.
