### PR TITLE
Robolimb Requirements

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -473,6 +473,12 @@ SUBSYSTEM_DEF(jobs)
 		if(job.title != "Cyborg" && job.title != "AI")
 			H.equip_post_job()
 
+		//Robolimb Control
+		if(H.client.prefs.cyber_control)
+			var/obj/item/weapon/implant/neural/N = new /obj/item/weapon/implant/neural
+			N.invisibility = 100
+			N.implant_loadout(H)
+
 		//If some custom items could not be equipped before, try again now.
 		for(var/thing in custom_equip_leftovers)
 			var/datum/gear/G = gear_datums[thing]

--- a/code/game/objects/items/weapons/implants/implantdud.dm
+++ b/code/game/objects/items/weapons/implants/implantdud.dm
@@ -77,7 +77,7 @@ Implant Specifics:<BR>"}
 <b>Important Notes:</b> None<BR>
 <HR>
 <b>Implant Details:</b> <BR>
-<b>Function:</b> Maintains some function or structure of the target's brain.<BR>
+<b>Function:</b> Maintains some function or structure of the target's brain. Also aids in the adaptation to and continued usage of cyberware and other augmentations.<BR>
 <b>Special Features:</b><BR>
 <i>Neuro-Safe</i>- Specialized shell absorbs excess voltages self-destructing the chip if
 a malfunction occurs thereby attempting to secure the safety of subject.<BR>

--- a/code/modules/client/preference_setup/general/05_body.dm
+++ b/code/modules/client/preference_setup/general/05_body.dm
@@ -44,6 +44,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	S["synth_blue"]			>> pref.b_synth
 	pref.preview_icon = null
 	S["bgstate"]			>> pref.bgstate
+	S["cyber_control"]		>> pref.cyber_control
 
 /datum/category_item/player_setup_item/general/body/save_character(var/savefile/S)
 	S["species"]			<< pref.species
@@ -78,6 +79,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	S["synth_green"]		<< pref.g_synth
 	S["synth_blue"]			<< pref.b_synth
 	S["bgstate"]			<< pref.bgstate
+	S["cyber_control"]		<< pref.cyber_control
 
 /datum/category_item/player_setup_item/general/body/delete_character(var/savefile/S)
 	pref.species = null
@@ -113,6 +115,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	pref.weight = null
 	pref.hydration = initial(pref.hydration)
 	pref.nutrition = initial(pref.nutrition)
+	pref.cyber_control = null
 
 /datum/category_item/player_setup_item/general/body/sanitize_character(var/savefile/S)
 	if(!pref.species || !(pref.species in playable_species))
@@ -148,6 +151,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	else pref.body_markings &= body_marking_styles_list
 	if(!pref.bgstate || !(pref.bgstate in pref.bgstate_options))
 		pref.bgstate = "000"
+
+	pref.cyber_control	= sanitize_integer(pref.cyber_control, initial(pref.cyber_control))
 
 // Moved from /datum/preferences/proc/copy_to()
 /datum/category_item/player_setup_item/general/body/copy_to_mob(var/mob/living/carbon/human/character)
@@ -380,6 +385,13 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		. += "\[...\]<br><br>"
 	else
 		. += "<br><br>"
+
+	if(LAZYLEN(pref.rlimb_data) && !pref.is_synth())
+		. += "<b>A neural framework implant is required to use cybernetic limbs. If you do not have one installed prior to saving your \
+		character, you WILL not be able to control cybernetic limbs, putting you at a significant disadvantage depending on the affected \
+		limbs. You will have to receive an implant during gameplay to use your cybernetic limbs in the future.</b><br>"
+		. += "<b>Neural Framework Implant Installed: </b><br>"
+		. += "<a href='?src=\ref[src];cyber_control=[pref.cyber_control]'><b>[pref.cyber_control ? "Yes" : "No"]</b></a><br>"
 
 	if(pref.is_synth())
 		. += "<div class='notice'><b>Warning:</b> You are playing a <b>synthetic</b>. In this universe, synthetics are limited rights and are not \
@@ -855,6 +867,10 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	else if(href_list["disabilities"])
 		var/disability_flag = text2num(href_list["disabilities"])
 		pref.disabilities ^= disability_flag
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["cyber_control"])
+		pref.cyber_control = !pref.cyber_control
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["toggle_preview_value"])

--- a/code/modules/client/preference_setup/general/05_body.dm
+++ b/code/modules/client/preference_setup/general/05_body.dm
@@ -387,9 +387,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		. += "<br><br>"
 
 	if(LAZYLEN(pref.rlimb_data) && !pref.is_synth())
-		. += "<b>A neural framework implant is required to use cybernetic limbs. If you do not have one installed prior to saving your \
+		. += "<div class='notice'><b>Warning: A neural framework implant is required to use cybernetic limbs.</b> If you do not have one installed prior to saving your \
 		character, you WILL not be able to control cybernetic limbs, putting you at a significant disadvantage depending on the affected \
-		limbs. You will have to receive an implant during gameplay to use your cybernetic limbs in the future.</b><br>"
+		limbs. You will have to receive an implant during gameplay to use your cybernetic limbs in the future.</div><br>"
 		. += "<b>Neural Framework Implant Installed: </b><br>"
 		. += "<a href='?src=\ref[src];cyber_control=[pref.cyber_control]'><b>[pref.cyber_control ? "Yes" : "No"]</b></a><br>"
 

--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -12,7 +12,7 @@
 	display_name = "implant, neural assistance web"
 	description = "A complex web implanted into the subject, medically in order to compensate for neurological disease."
 	path = /obj/item/weapon/implant/neural
-	cost = 1
+	cost = 0
 
 /datum/gear/cyberware/dud2
 	display_name = "implant, torso"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -183,6 +183,8 @@ datum/preferences
 	var/savecharcooldown
 	var/loadcharcooldown
 
+	var/cyber_control = FALSE //Allows players to use cyberware on spawn
+
 /datum/preferences/New(client/C)
 	player_setup = new(src)
 	set_biological_gender(pick(MALE, FEMALE))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -167,6 +167,18 @@
 /proc/isLivingSSD(mob/living/M)
 	return istype(M) && !M.client || !M.key && M.stat != DEAD
 
+/mob/living/carbon/human/proc/can_use_cyberware()
+	if(isSynthetic())
+		return TRUE
+
+	else
+		var/obj/item/organ/external/H = organs_by_name["head"]
+
+		if(locate(/obj/item/weapon/implant/neural) in H.contents)
+			return TRUE
+		else
+			return FALSE
+
 #undef HUMAN_EATING_NO_ISSUE
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1145,6 +1145,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 0
 
 /obj/item/organ/external/proc/is_usable()
+	if(robotic >= ORGAN_ROBOT && (owner.can_use_cyberware() == FALSE))
+		return FALSE
+
 	return !(status & (ORGAN_MUTATED|ORGAN_DEAD))
 
 /obj/item/organ/external/proc/is_malfunctioning()

--- a/code/modules/persistence/persistent_characters.dm
+++ b/code/modules/persistence/persistent_characters.dm
@@ -67,12 +67,17 @@
 	for(var/limb in BP_ALL)
 		var/obj/item/organ/external/current_limb = organs_by_name[limb]
 
+		if(limb == "head")
+			//check for neural framework implant
+			if(!mind.prefs.cyber_control)
+				if(current_limb.contents.Find(/obj/item/weapon/implant/neural)) //If one was added during this round, save it
+					mind.prefs.cyber_control = TRUE
+
 		if(isnull(current_limb))
 			if((limb == "groin") || (limb == "head"))
 				//do nothing
 			else
 				mind.prefs.organ_data[limb] = "amputated"
-
 		else
 			if(current_limb.robotic)
 				if(istype(current_limb, /obj/item/organ/external/head))

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -581,6 +581,14 @@ other types of metals and chemistry for reagents).
 	protected = TRUE
 	price = 500
 
+/datum/design/item/implant/neural
+	name = "neural"
+	id = "implant_neural"
+	req_tech = list(TECH_BIO = 3, TECH_DATA = 3)
+	build_path = /obj/item/weapon/implant/neural
+	sort_string = "MFAAC"
+	price = 750
+
 /datum/design/item/weapon/AssembleDesignName()
 	..()
 	name = "Weapon prototype ([item_name])"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- A neural framework implant is now required to use robolimbs. Spawning with the implant can be toggled in the preferences menu.
- If a player has robolimbs and does not have a neural framework implant, their limbs will not be able to function.
- Synthetic characters (Positronics and Drones) do not require a neural framework implant to use robolimbs.
- Implantation of a neural framework implant is now persistent. If a player who does not have the neural framework implant has one implanted during a round - during subsequent rounds, they will automatically have on installed.
- By default, the implant is NOT installed. A disclaimer has been added to the preferences menu to warn players of the importance of having the neural framework implant.
- Neural Framework Implant added to protolathe designs. Recommended price: 750CR
- IMPORTANT NOTICE: After 2 weeks of the approval of this PR, the ability to change one's implant status will be removed. This means that after saving the slot, the option to toggle implant status will be inaccessible. You have TWO WEEKS to make sure any characters you have with robolimbs are properly implanted if you want them to continue using their robolimbs unimpeded. This is as simple as toggling the implant status to YES and saving the slot. Once again, AFTER TWO WEEKS players will not be able to change the implant status of existing characters. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a mechanical aspect to whether or not one would like to have robolimbs for their character. Also a pre-requisite for additional cyberware PRs whereby augments such as internal blades, firearms, and other utilities require the implant before they can be used.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Neural Framework Implant is required to use robotic limbs for non-synthetics.
add: Neural Framework Implant added to protolathe designs - TECH_BIO 3, TECH_DATA 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->