### PR TITLE
Amber Slime + Green Slime Rebalance

### DIFF
--- a/code/modules/bounty/presets/xenobio.dm
+++ b/code/modules/bounty/presets/xenobio.dm
@@ -126,7 +126,6 @@
 
 	days_until_expiry = 2
 
-/*
 /datum/bounty/xenobio/uranium_fever
 	name = "Uranium Fever"
 	author = "Goop LLC."
@@ -139,7 +138,7 @@
 	individual_reward = 430
 
 	days_until_expiry = 2
-*/
+
 /datum/bounty/xenobio/healing_goop
 	name = "Healing Goop"
 	author = "Goop LLC."
@@ -166,7 +165,6 @@
 
 	days_until_expiry = 2
 
-/*
 /datum/bounty/xenobio/slime_snax
 	name = "Slime Snax"
 	author = "Goop LLC."
@@ -179,7 +177,6 @@
 	individual_reward = 510
 
 	days_until_expiry = 2
-*/
 
 /datum/bounty/xenobio/project_promethean
 	name = "Project Promethean"

--- a/code/modules/bounty/presets/xenobio.dm
+++ b/code/modules/bounty/presets/xenobio.dm
@@ -126,6 +126,7 @@
 
 	days_until_expiry = 2
 
+/*
 /datum/bounty/xenobio/uranium_fever
 	name = "Uranium Fever"
 	author = "Goop LLC."
@@ -138,7 +139,7 @@
 	individual_reward = 430
 
 	days_until_expiry = 2
-
+*/
 /datum/bounty/xenobio/healing_goop
 	name = "Healing Goop"
 	author = "Goop LLC."
@@ -165,6 +166,7 @@
 
 	days_until_expiry = 2
 
+/*
 /datum/bounty/xenobio/slime_snax
 	name = "Slime Snax"
 	author = "Goop LLC."
@@ -177,6 +179,7 @@
 	individual_reward = 510
 
 	days_until_expiry = 2
+*/
 
 /datum/bounty/xenobio/project_promethean
 	name = "Project Promethean"

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -505,7 +505,7 @@
 	coretype = /obj/item/slime_extract/green
 	glow_toggle = TRUE
 	reagent_injected = "radium"
-	var/rads = 5
+	var/rads = 1
 
 	description_info = "This slime will cause plants to randomly mutate, and will inject radium on attack.  \
 	A radsuit or other thick and radiation-hardened armor can protect from this.  It will only radiate while alive."

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -526,7 +526,7 @@
 
 /mob/living/simple_mob/slime/xenobio/green/proc/irradiate()
 	SSradiation.radiate(src, rads)
-	for(/obj/machinery/portable_atmospherics/hydroponics/G in range(7,src))
+	for(var/obj/machinery/portable_atmospherics/hydroponics/G in range(7,src))
 		G.mutation_level++
 		G.toxins += 0.1
 

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -145,7 +145,8 @@
 			/mob/living/simple_mob/slime/xenobio/bluespace,
 			/mob/living/simple_mob/slime/xenobio/bluespace,
 			/mob/living/simple_mob/slime/xenobio/metal,
-			/mob/living/simple_mob/slime/xenobio/orange
+			/mob/living/simple_mob/slime/xenobio/orange,
+			/mob/living/simple_mob/slime/xenobio/green
 		)
 
 /mob/living/simple_mob/slime/xenobio/yellow/apply_melee_effects(atom/A)
@@ -447,7 +448,7 @@
 			continue
 		if(istype(L, /mob/living/simple_mob/slime/xenobio))
 			var/mob/living/simple_mob/slime/xenobio/X = L
-			X.adjust_nutrition(rand(15, 25))
+			X.adjust_nutrition(rand(2, 5))
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			if(H.isSynthetic())
@@ -504,9 +505,9 @@
 	coretype = /obj/item/slime_extract/green
 	glow_toggle = TRUE
 	reagent_injected = "radium"
-	var/rads = 25
+	var/rads = 5
 
-	description_info = "This slime will irradiate anything nearby passively, and will inject radium on attack.  \
+	description_info = "This slime will cause plants to randomly mutate, and will inject radium on attack.  \
 	A radsuit or other thick and radiation-hardened armor can protect from this.  It will only radiate while alive."
 	player_msg = "You <b>passively irradiate your surroundings</b>.<br>\
 	You also inject radium on attack."
@@ -525,6 +526,9 @@
 
 /mob/living/simple_mob/slime/xenobio/green/proc/irradiate()
 	SSradiation.radiate(src, rads)
+	for(/obj/machinery/portable_atmospherics/hydroponics/G in range(7,src))
+		G.mutation_level++
+		G.toxins += 0.1
 
 
 
@@ -596,7 +600,8 @@
 			/mob/living/simple_mob/slime/xenobio/metal,
 			/mob/living/simple_mob/slime/xenobio/gold,
 			/mob/living/simple_mob/slime/xenobio/sapphire,
-			/mob/living/simple_mob/slime/xenobio/sapphire
+			/mob/living/simple_mob/slime/xenobio/sapphire,
+			/mob/living/simple_mob/slime/xenobio/amber
 		)
 
 /mob/living/simple_mob/slime/xenobio/gold/slimebatoned(mob/living/user, amount)

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -16,7 +16,6 @@
 	slime_mutation = list(
 			/mob/living/simple_mob/slime/xenobio/dark_purple,
 			/mob/living/simple_mob/slime/xenobio/dark_blue,
-			/mob/living/simple_mob/slime/xenobio/green,
 			/mob/living/simple_mob/slime/xenobio
 		)
 
@@ -287,8 +286,6 @@
 	slime_mutation = list(
 			/mob/living/simple_mob/slime/xenobio/metal,
 			/mob/living/simple_mob/slime/xenobio/blue,
-			/mob/living/simple_mob/slime/xenobio/amber,
-			/mob/living/simple_mob/slime/xenobio/amber
 		)
 
 /mob/living/simple_mob/slime/xenobio/silver/bullet_act(var/obj/item/projectile/P, var/def_zone)
@@ -709,8 +706,6 @@
 	description_info = "This slime will make everything around it, and itself, faster for a few seconds, if close by."
 
 	slime_mutation = list(
-		/mob/living/simple_mob/slime/xenobio/green,
-		/mob/living/simple_mob/slime/xenobio/green,
 		/mob/living/simple_mob/slime/xenobio/emerald,
 		/mob/living/simple_mob/slime/xenobio/emerald
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Removes amber and green slimes from slime mutation list.~~ Amber slimes, if escaped, cause a runaway reproduction effect that can crash the server. Green slimes have been removed due to balancing issues, and in conjuction with amber slimes can irradiate the city and kill everyone. They're just not good.!!

Due to an accident, over 5000 slimes were spawned over the course of an hour. This should never happen.

Amber slimes now provide much less nutrition to other slimes. Roughly 80% less. Green slimes are now much less radioactive and can now mutate growing plants near them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Anti-grief, anti-crash. Good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: amber slimes now provide much less nutrition to other slimes
tweak: green slimes are now much less radioactive and can mutate plants if left near them long enough
tweak: green slimes have been added to tier 3 slimes
remove: redspace slimes removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->